### PR TITLE
Add simple docs explaining how Manon can be installed to read the documentation.

### DIFF
--- a/docs/documentation/documentation.html
+++ b/docs/documentation/documentation.html
@@ -67,13 +67,13 @@
               <p>Manon maakt gebruik <a href="https://pnpm.io/installation">pnpm</a>, een package die beschikbaar is via npm.</p>
               <ol>
                 <li>
-                    pnpm installeren: <code>npm install -g pnpm </code> 
-                </li>
-                <li>
                     Manon downloaden: <code>git clone https://github.com/minvws/nl-rdo-manon.git</code>
                 </li>
                 <li>
-                    Open de folder waar Manon is geïnstalleerd: <code>cd /manon/install/folder</code>
+                    Open de folder waar Manon is geïnstalleerd, bijvoorbeeld: <code>cd /manon/install/folder</code>
+                </li>
+                <li>
+                    pnpm installeren: <code>npm install pnpm </code> 
                 </li>
                 <li>
                     Dependencies installeren: <code>pnpm install</code>

--- a/docs/documentation/documentation.html
+++ b/docs/documentation/documentation.html
@@ -70,7 +70,7 @@
                     Manon downloaden: <code>git clone https://github.com/minvws/nl-rdo-manon.git</code>
                 </li>
                 <li>
-                    Open de folder waar Manon is geïnstalleerd, bijvoorbeeld: <code>cd /manon/install/folder</code>
+                    Open de folder waar Manon is geïnstalleerd, bijvoorbeeld: <code>cd nl-rdo-manon</code>
                 </li>
                 <li>
                     Bekijk de pnpm <a href=" https://pnpm.io/installation">installatie instructies</a>
@@ -85,7 +85,7 @@
                     SCSS compilen naar CSS: <code>pnpm run build</code>
                 </li>
                 <li>
-                    De documentatie is nu lokaal te bekijken door het volgende bestand te openen, bijvoorbeeld: <code>/manon/install/folder/docs/index.html</code>
+                    De documentatie is nu lokaal te bekijken door het bestand <code>nl-rdo-manon/docs/index.html</code> te openen in je webbrowser
                 </li>
               </ol>
           </section>

--- a/docs/documentation/documentation.html
+++ b/docs/documentation/documentation.html
@@ -73,19 +73,19 @@
                     Open de folder waar Manon is geïnstalleerd, bijvoorbeeld: <code>cd /manon/install/folder</code>
                 </li>
                 <li>
-                    pnpm installeren: <code>npm install pnpm </code> 
+                    Bekijk de pnpm <a href=" https://pnpm.io/installation">installatie instructies</a>
                 </li>
                 <li>
                     Dependencies installeren: <code>pnpm install</code>
                 </li>
                 <li>
-                    Open de Manon documentatie folder: <code>cd /manon/install/folder/docs</code>
+                    Open de Manon documentatie folder: <code>cd docs</code>
                 </li>
                 <li>
                     SCSS compilen naar CSS: <code>pnpm run build</code>
                 </li>
                 <li>
-                    De documentatie is nu lokaal te bekijken door het volgende bestand te openen: <code>/manon/install/folder/docs/index.html</code>
+                    De documentatie is nu lokaal te bekijken door het volgende bestand te openen, bijvoorbeeld: <code>/manon/install/folder/docs/index.html</code>
                 </li>
               </ol>
           </section>

--- a/docs/documentation/documentation.html
+++ b/docs/documentation/documentation.html
@@ -59,8 +59,35 @@
           <section id="manon-quick-start">
             <h1>Manon gebruiken binnen een project.</h1>
             <p class="warning" role="group" aria-label="let op">
-              <span>Let op:</span> Aan deze instructies wordt nog gewerkt.
-            </p>
+                <span>Let op:</span> Aan deze instructies wordt nog gewerkt.
+              </p>
+          </section>
+          <section>
+              <h2>Manon installeren (lokaal docs bekijken)</h2>
+              <p>Manon maakt gebruik <a href="https://pnpm.io/installation">pnpm</a>, een package die beschikbaar is via npm.</p>
+              <ol>
+                <li>
+                    pnpm installeren: <code>npm install -g pnpm </code> 
+                </li>
+                <li>
+                    Manon downloaden: <code>git clone https://github.com/minvws/nl-rdo-manon.git</code>
+                </li>
+                <li>
+                    Open de folder waar Manon is geïnstalleerd: <code>cd /manon/install/folder</code>
+                </li>
+                <li>
+                    Dependencies installeren: <code>pnpm install</code>
+                </li>
+                <li>
+                    Open de Manon documentatie folder: <code>cd /manon/install/folder/docs</code>
+                </li>
+                <li>
+                    SCSS compilen naar CSS: <code>pnpm run build</code>
+                </li>
+                <li>
+                    De documentatie is nu lokaal te bekijken door het volgende bestand te openen: <code>/manon/install/folder/docs/index.html</code>
+                </li>
+              </ol>
           </section>
         </div>
       </article>


### PR DESCRIPTION
Super basic documentation so that users can at least get Manon up and running locally to play around with it.