### PR TITLE
fix: Removed redundant link

### DIFF
--- a/docs/documentation/components/max-line-length.html
+++ b/docs/documentation/components/max-line-length.html
@@ -5,7 +5,6 @@
     <title>Maximale regellengte</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="../../static/css/main.css" rel="stylesheet" />
-    <link href="../../../manon/scss/text/max-line-length.css" rel="stylesheet" />
     <link href="../../static/img/favicon.ico" rel="shortcut icon" />
     <script defer src="../../static/js/manon.js"></script>
   </head>


### PR DESCRIPTION
fix: Removed redundant link within max-line-length.html. As max-line-length is currently in use on all the docs pages it's no longer necessary to specify it on the max-line-length page.