### PR TITLE
fix: table cells html

### DIFF
--- a/docs/documentation/components/max-line-length.html
+++ b/docs/documentation/components/max-line-length.html
@@ -115,7 +115,7 @@
                   </tr>
 
                   <tr>
-                    <th rowspan="2" scope="rowgroup">hyphens</th>
+                    <td rowspan="2" scope="rowgroup">hyphens</td>
                     <td>Voor breekpunt</td>
                     <td>--max-line-length-hyphens</td>
                     <td rowspan="2" scope="rowgroup"><a href="../variables.html#hyphens">hyphens</a></td>
@@ -130,7 +130,7 @@
                   </tr>
 
                   <tr>
-                    <th rowspan="2" scope="rowgroup">word-break</th>
+                    <td rowspan="2" scope="rowgroup">word-break</td>
                     <td>Voor breekpunt</td>
                     <td>--max-line-length-word-break</td>
                     <td rowspan="2" scope="rowgroup"><a href="../variables.html#word-break">word-break</a></td>


### PR DESCRIPTION
fix: table cells html use td instead of th where needed.