### PR TITLE
fix: section, article and base title margin

### DIFF
--- a/docs/documentation/components/article.html
+++ b/docs/documentation/components/article.html
@@ -113,10 +113,7 @@
               <li>
                 Titel en subitels:
                 <ul>
-                  <li><a href="../variables.html#margin-top">margin-top</a></li>
-                  <li>
-                    <a href="../variables.html#margin-bottom">margin-bottom</a>
-                  </li>
+                  <li><a href="../variables.html#margin">margin</a></li>
                 </ul>
               </li>
               <li>

--- a/docs/documentation/components/layout-base.html
+++ b/docs/documentation/components/layout-base.html
@@ -91,10 +91,7 @@
                     Op titels en subtitels:
                     <ul>
                       <li>
-                        <a href="../variables.html#margin-top">margin-top</a>
-                      </li>
-                      <li>
-                        <a href="../variables.html#margin-bottom">margin-bottom</a>
+                        <a href="../variables.html#margin">margin</a>
                       </li>
                     </ul>
                   </li>

--- a/docs/documentation/components/section.html
+++ b/docs/documentation/components/section.html
@@ -113,10 +113,7 @@
               <li>
                 Titel en subitels:
                 <ul>
-                  <li><a href="../variables.html#margin-top">margin-top</a></li>
-                  <li>
-                    <a href="../variables.html#margin-bottom">margin-bottom</a>
-                  </li>
+                  <li><a href="../variables.html#margin">margin</a></li>
                 </ul>
               </li>
               <li>

--- a/manon/article-variables.scss
+++ b/manon/article-variables.scss
@@ -9,18 +9,10 @@
   /* --article-text-color: ; */
 
   /* article title */
-  --article-title-margin-top: var(--layout-base-content-block-title-margin-top);
-  --article-title-margin-bottom: var(
-    --layout-base-content-block-title-margin-bottom
-  );
+  --article-title-margin: var(--layout-base-content-block-title-margin);
 
   /* article subtitle */
-  --article-subtitle-margin-top: var(
-    --layout-base-content-block-subtitle-margin-top
-  );
-  --article-subtitle-margin-bottom: var(
-    --layout-base-content-block-subtitle-margin-bottom
-  );
+  --article-subtitle-margin: var(--layout-base-content-block-subtitle-margin);
 
   /* Content block within article's */
   --article-content-block-gap: var(--article-gap);

--- a/manon/article.scss
+++ b/manon/article.scss
@@ -23,23 +23,19 @@ main article {
     gap: var(--article-content-block-gap);
 
     h1 {
-      margin-top: var(--article-title-margin-top);
-      margin-bottom: var(--article-title-margin-bottom);
+      margin: var(--article-title-margin);
     }
 
     h2 {
-      margin-top: var(--article-subtitle-margin-top);
-      margin-bottom: var(--article-subtitle-margin-bottom);
+      margin: var(--article-subtitle-margin);
     }
   }
 
   h1 {
-    margin-top: var(--article-title-margin-top);
-    margin-bottom: var(--article-title-margin-bottom);
+    margin: var(--article-title-margin);
   }
 
   h2 {
-    margin-top: var(--article-subtitle-margin-top);
-    margin-bottom: var(--article-subtitle-margin-bottom);
+    margin: var(--article-subtitle-margin);
   }
 }

--- a/manon/layout-base-variables.scss
+++ b/manon/layout-base-variables.scss
@@ -21,9 +21,7 @@
   --layout-base-within-content-block-gap: 2rem;
 
   /* Titles */
-  --layout-base-content-block-title-margin-top: 2rem;
-  --layout-base-content-block-title-margin-bottom: 0;
+  --layout-base-content-block-title-margin: var(--heading-xl-margin);
 
-  --layout-base-content-block-subtitle-margin-top: 2rem;
-  --layout-base-content-block-subtitle-margin-bottom: 0;
+  --layout-base-content-block-subtitle-margin: var(--heading-large-margin);
 }

--- a/manon/section-variables.scss
+++ b/manon/section-variables.scss
@@ -9,18 +9,10 @@
   /* --section-text-color: ; */
 
   /* Section title */
-  --section-title-margin-top: var(--layout-base-content-block-title-margin-top);
-  --section-title-margin-bottom: var(
-    --layout-base-content-block-title-margin-bottom
-  );
+  --section-title-margin: var(--layout-base-content-block-title-margin);
 
   /* Section subtitle */
-  --section-subtitle-margin-top: var(
-    --layout-base-content-block-subtitle-margin-top
-  );
-  --section-subtitle-margin-bottom: var(
-    --layout-base-content-block-subtitle-margin-bottom
-  );
+  --section-subtitle-margin: var(--layout-base-content-block-subtitle-margin);
 
   /* Content block within sections */
   --section-content-block-gap: var(--section-gap);

--- a/manon/section.scss
+++ b/manon/section.scss
@@ -23,23 +23,19 @@ main section {
     gap: var(--section-content-block-gap);
 
     h1 {
-      margin-top: var(--section-title-margin-top);
-      margin-bottom: var(--section-title-margin-bottom);
+      margin: var(--section-title-margin);
     }
 
     h2 {
-      margin-top: var(--section-subtitle-margin-top);
-      margin-bottom: var(--section-subtitle-margin-bottom);
+      margin: var(--section-subtitle-margin);
     }
   }
 
   h1 {
-    margin-top: var(--section-title-margin-top);
-    margin-bottom: var(--section-title-margin-bottom);
+    margin: var(--section-title-margin);
   }
 
   h2 {
-    margin-top: var(--section-subtitle-margin-top);
-    margin-bottom: var(--section-subtitle-margin-bottom);
+    margin: var(--section-subtitle-margin);
   }
 }


### PR DESCRIPTION
- Changed section, article and base title margin to match with headings styling

BREAKING: 
Article
Removed: --article-title-margin-top
Removed: --article-title-margin-bottom 
Use instead: --article-title-margin

Section
Removed:--section-title-margin-top
Removed:--section-title-margin-bottom 
Use instead: --section-title-margin

Layout base
Removed:--layout-base-content-block-title-margin-top
Removed:--layout-base-content-block-title-margin-bottom 
Use instead:--layout-base-content-block-title-margin