### PR TITLE
fix: fieldset checkbox alignment horizontal view. 

### DIFF
--- a/manon/form-horizontal-view-fieldset.scss
+++ b/manon/form-horizontal-view-fieldset.scss
@@ -24,10 +24,12 @@ and: https://bugs.chromium.org/p/chromium/issues/detail?id=262679 */
 form.horizontal-view {
   > fieldset {
     > div {
+      gap: 0; /* resetting gap as it can not be used within fieldsets */
+      
       @media (min-width: $breakpoint) {
         > * {
-          width: var(--form-horizontal-view-input-max-width);
-
+          width: calc(var(--form-horizontal-view-input-max-width) - var(--form-horizontal-view-gap));
+          gap: 0; /* resetting gap as it can not be used within fieldsets */
           /* float objects to move inputs into place even when there is no label */
           float: right; 
         }


### PR DESCRIPTION
fix: fieldset checkbox alignment horizontal view. Align correctly with elements outside the fieldset.