### PR TITLE
fix: set border to 0 on focus-only class

### DIFF
--- a/manon/focus-only.scss
+++ b/manon/focus-only.scss
@@ -12,5 +12,6 @@
     font-size: 0;
     padding: 0;
     min-height: 0;
+    border: 0;
   }
 }


### PR DESCRIPTION
Currently the button to go the content adds white space on top of the page.

```
<a href="#main-content" class="button focus-only">Ga direct naar inhoud</a>
```

This PR sets the border to 0 and that removed the whitespace on top of the page.