### PR TITLE
Update nav styling

### DIFF
--- a/docs/scss/themes/soft/body-text-set.scss
+++ b/docs/scss/themes/soft/body-text-set.scss
@@ -3,7 +3,7 @@
 :root {
 	/* Available variables to use within all text types */
 	--text-set-font-family: "Open Sans", sans-erif;
-	--text-set-font-size: 1.25rem;
+	--text-set-font-size: 1rem;
 	--text-set-font-weight: normal;
 	--text-set-strong-font-weight: 600;
 	--text-set-line-height: 1.75;

--- a/docs/scss/themes/soft/header-navigation.scss
+++ b/docs/scss/themes/soft/header-navigation.scss
@@ -3,5 +3,24 @@
 :root {
     --header-navigation-background-color: transparent;
     --header-navigation-text-color: var(--text-set-text-color);
-    --header-navigation-justify-content: flex-end;
+    --header-navigation-min-height: 0;
+    --header-navigation-padding-right: 2rem;
+    --header-navigation-padding-left: 2rem;
+
+    /* top border */
+    --header-navigation-border-width: 3px 0 0 0;
+    --header-navigation-border-color: var(--branding-color-1);
+
+    /* Menu items */
+    --header-navigation-link-border-width: 4px 0 0 0;
+    --header-navigation-link-border-color: transparent;
+    --header-navigation-link-min-height: 3rem;
+    --header-navigation-link-font-size: var(--body-text-medium-font-size);
+
+    /* Hover */
+    --header-navigation-link-hover-border-color: #ede1c7;
+    --header-navigation-link-hover-text-color: var(--application-base-text-color);
+
+    /* Active link */
+    --header-navigation-link-active-border-color: var(--branding-color-1);
 }

--- a/manon/breadcrumb-bar-variables.scss
+++ b/manon/breadcrumb-bar-variables.scss
@@ -6,13 +6,18 @@
   --breadcrumb-bar-justify-content: flex-start;
   --breadcrumb-bar-align-items: center;
   --breadcrumb-bar-gap: 0;
-  --breadcrumb-bar-padding-top: 1rem;
+  --breadcrumb-bar-padding-top: 0;
   --breadcrumb-bar-padding-right: 0;
-  --breadcrumb-bar-padding-bottom: 1rem;
+  --breadcrumb-bar-padding-bottom: 0;
   --breadcrumb-bar-padding-left: 0;
   --breadcrumb-bar-max-width: 100%;
   --breadcrumb-bar-background-color: var(--branding-color-accent-5);
   --breadcrumb-bar-text-color: var(--application-base-text-color);
+  --breadcrumb-bar-border-width: 0;
+  --breadcrumb-bar-border-style: solid;
+  --breadcrumb-bar-border-color: transparent;
+  --breadcrumb-bar-border-radius: 0;
+  --breadcrumb-bar-min-height: 0;
 
   /* Hover */
   --breadcrumb-bar-hover-text-color: var(--application-base-text-color);
@@ -30,7 +35,7 @@
   --breadcrumb-bar-icon-margin-left: 0;
   --breadcrumb-bar-icon-margin-right: 0;
 
-  /* Last item */
+  /* Last item / current page */
   --breadcrumb-bar-list-item-last-child-font-weight: bold;
 
   /* Link */

--- a/manon/breadcrumb-bar.scss
+++ b/manon/breadcrumb-bar.scss
@@ -11,6 +11,7 @@
   gap: var(--breadcrumb-bar-gap);
   width: 100%;
   margin: 0 auto;
+  min-height: var(--breadcrumb-bar-min-height);
   box-sizing: border-box;
   padding-top: var(--breadcrumb-bar-padding-top);
   padding-right: var(--breadcrumb-bar-padding-right);
@@ -20,6 +21,10 @@
   flex-wrap: wrap;
   background-color: var(--breadcrumb-bar-background-color);
   color: var(--breadcrumb-bar-text-color);
+  border-width: var(--breadcrumb-bar-border-width);
+  border-style: var(--breadcrumb-bar-border-style);
+  border-color: var(--breadcrumb-bar-border-color);
+  border-radius: var(--breadcrumb-bar-border-radius);
 
   ul,
   ol {
@@ -66,13 +71,25 @@
         word-break: break-word; /* Break words that won't fit the available space */
         color: inherit;
         text-decoration: var(--breadcrumb-bar-link-text-decoration);
+        border: 0;
 
         &:hover {
           text-decoration: var(--breadcrumb-bar-link-hover-text-decoration);
+          border: 0;
         }
 
         &:before {
           content: none;
+        }
+
+        &[aria-current="page"] {
+          border: 1px dashed red;
+          border: 0;
+          font-weight: var(--breadcrumb-bar-list-item-last-child-font-weight);
+
+          &:hover {
+            border: 0;
+          }
         }
       }
     }

--- a/manon/header-navigation-variables.scss
+++ b/manon/header-navigation-variables.scss
@@ -6,7 +6,7 @@
   --header-navigation-gap: 2rem;
   --header-navigation-justify-content: flex-start;
   --header-navigation-align-items: center;
-  --header-navigation-min-height: 4rem;
+  --header-navigation-min-height: 0;
   --header-navigation-width: 100%;
   --header-navigation-padding-top: 0;
   --header-navigation-padding-right: 0;
@@ -16,6 +16,10 @@
   --header-navigation-background-color: var(--application-base-accent-color);
   --header-navigation-text-color: var(--application-base-accent-color-text-color);
   --header-navigation-max-width: 100%;
+  --header-navigation-border-width: 0;
+  --header-navigation-border-style: solid;
+  --header-navigation-border-color: transparent;
+  --header-navigation-border-radius: 0;
   
   /* Content wrapper - Usualy a div to match main content alignment */
   --header-navigation-content-wrapper-padding-top: 0;
@@ -39,27 +43,50 @@
   --header-navigation-list-item-align-items: var(--header-navigation-align-items);
   
   /* Link */
-  --header-navigation-link-text-decoration: none;
   --header-navigation-link-justify-content: center;
   --header-navigation-link-align-items: center;
   --header-navigation-link-padding-top: 0;
   --header-navigation-link-padding-right: 0;
   --header-navigation-link-padding-bottom: 0;
   --header-navigation-link-padding-left: 0;
+  --header-navigation-link-min-height: 0;
+  --header-navigation-link-text-decoration: none;
   --header-navigation-link-text-color: var(--header-navigation-text-color, black);
+  --header-navigation-link-font-size: var(--text-set-font-size);
+  --header-navigation-link-line-height: var(--text-set-line-height);
+  --navigation-link-font-weight: var(--text-set-font-weight);
+  --header-navigation-link-border-width: 0;
+  --header-navigation-link-border-style: solid;
+  --header-navigation-link-border-color: transparent;
+  --header-navigation-link-border-radius: 0;
+
+  /* Link hover */
+  --header-navigation-link-hover-text-decoration: none;
+  --header-navigation-link-hover-background-color: transparent;
+  --header-navigation-link-hover-text-color: var(--header-navigation-text-color);
+  --header-navigation-link-hover-border-width: var(--header-navigation-link-border-width);
+  --header-navigation-link-hover-border-style: var(--header-navigation-link-border-style);
+  --header-navigation-link-hover-border-color: transparent;
+  --header-navigation-link-hover-border-radius: var(--header-navigation-link-border-radius);
+  --header-navigation-link-hover-font-weight: normal;
 
   /* Link visited */
   --header-navigation-link-visited-text-color: var(--header-navigation-link-text-color);
 
-  /* Link hover */
-  --header-navigation-link-hover-text-decoration: underline;
-  --header-navigation-link-hover-background-color: transparent;
-  --header-navigation-link-hover-text-color: var(--header-navigation-text-color);
+  /* Link visited hover */
+  --header-navigation-link-visited-hover-text-decoration: var(--header-navigation-link-hover-text-decoration);
+  --header-navigation-link-visited-hover-background-color: var(--header-navigation-link-hover-background-color);
+  --header-navigation-link-visited-hover-text-color: var(--header-navigation-link-hover-text-color);
 
-  /* Link hover */
+  /* Link active */
   --header-navigation-link-active-text-decoration: var(--header-navigation-link-hover-text-decoration);
   --header-navigation-link-active-background-color: var(--header-navigation-link-hover-background-color);
   --header-navigation-link-active-text-color: var(--header-navigation-link-hover-text-color);
+  --header-navigation-link-active-border-width: var(--header-navigation-link-border-width);
+  --header-navigation-link-active-border-style: var(--header-navigation-link-border-style);
+  --header-navigation-link-active-border-color: transparent;
+  --header-navigation-link-active-border-radius: var(--header-navigation-link-border-radius);
+  --header-navigation-link-active-font-weight: normal;
 
   /* Button */
   --header-navigation-button-justify-content: var(--button-base-justify-content, center);

--- a/manon/header-navigation.scss
+++ b/manon/header-navigation.scss
@@ -4,14 +4,22 @@
 @use "header-navigation-variables";
 %active-link {
   text-decoration: var(--header-navigation-link-active-text-decoration);
-  background-color: var(-header-navigation-link-active-background-color);
+  background-color: var(--header-navigation-link-active-background-color);
   color: var(--header-navigation-link-active-text-color);
-  
+  border-width: var(--header-navigation-link-active-border-width);
+  border-style: var(--header-navigation-link-active-border-style);
+  border-color: var(--header-navigation-link-active-border-color);
+  border-radius: var(--header-navigation-link-active-border-radius);
+  font-weight: var(--header-navigation-link-active-font-weight);
 
   &:hover {
     text-decoration: var(--header-navigation-link-active-hover-text-decoration);
     background-color: var(-header-navigation-link-active-hover-background-color);
     color: var(--header-navigation-link-active-hover-text-color);
+    border-width: var(--header-navigation-link-hover-border-width);
+    border-style: var(--header-navigation-link-hover-border-style);
+    border-color: var(--header-navigation-link-hover-border-color);
+    border-radius: var(--header-navigation-link-hover-border-radius);
   }
 }
 
@@ -36,13 +44,16 @@ body > header,
     padding-bottom: var(--header-navigation-padding-bottom);
     padding-left: var(--header-navigation-padding-left);
     max-width: var(--header-navigation-max-width);
+    border-width: var(--header-navigation-border-width);
+    border-style: var(--header-navigation-border-style);
+    border-color: var(--header-navigation-border-color);
+    border-radius: var(--header-navigation-border-radius);
 
-    > button,
-    > a.button,
-    > input[type="button"],
-    > input[type="submit"],
-    > input[type="reset"]  {
-
+    button,
+    a.button,
+    input[type="button"],
+    input[type="submit"],
+    input[type="reset"]  {
       justify-content: var(--header-navigation-button-justify-content);
       align-self: var(--header-navigation-button-align-self);
       min-width: var(--header-navigation-button-min-width);
@@ -71,7 +82,6 @@ body > header,
 
       &:hover {
         text-decoration: var(--header-navigation-link-hover-text-decoration);
-        color: inherit;
         background-color: var(--header-navigation-link-hover-background-color);
         color: var(--header-navigation-link-hover-text-color);
       }
@@ -103,34 +113,34 @@ body > header,
           }
         }
 
-        a,
-        a.button {
+        a {
           display: flex;
           justify-content: var(--header-navigation-link-justify-content);
           align-items: var(--header-navigation-link-align-items);
-          min-width: var(--header-navigation-button-min-width);
-          min-heigt: var(--header-navigation-button-min-height);
-          background-color: var(--header-navigation-button-background-color);
-          color: var(--header-navigation-link-text-color);
-          height: 100%;
-
-          border-width: var(--header-navigation-button-border-width);
-          border-style: var(--header-navigation-button-border-style);
-          border-color: var(--header-navigation-button-border-color);
-          border-radius: var(--header-navigation-button-border-radius);
-
           padding-top: var(--header-navigation-link-padding-top);
           padding-right: var(--header-navigation-link-padding-right);
           padding-bottom: var(--header-navigation-link-padding-bottom);
           padding-left: var(--header-navigation-link-padding-left);
-
-          font-size: var(--header-navigation-button-font-size);
-          line-height: var(--header-navigation-button-line-height);
-          font-weight: var(--header-navigation-button-font-weight);
+          min-height: var(--header-navigation-link-min-height);
+          height: 100%;
           text-decoration: var(--header-navigation-link-text-decoration);
+          color: var(--header-navigation-link-text-color);
+          font-size: var(--header-navigation-link-font-size);
+          line-height: var(--header-navigation-link-line-height);
+          font-weight: var(--header-navigation-link-font-weight);
+          border-width: var(--header-navigation-link-border-width);
+          border-style: var(--header-navigation-link-border-style);
+          border-color: var(--header-navigation-link-border-color);
+          border-radius: var(--header-navigation-link-border-radius);
 
           &:visited {
             color: var(--header-navigation-link-visited-text-color);
+            
+            &:hover {
+              text-decoration: var(--header-navigation-link-visited-hover-text-decoration);
+              background-color: var(--header-navigation-link-visited-hover-background-color);
+              color: var(--header-navigation-link-visited-hover-text-color);
+            }
           }
 
           /* aria current on a */
@@ -141,11 +151,11 @@ body > header,
           &:hover {
             background-color: var(--header-navigation-link-hover-background-color);
             color: var(--header-navigation-link-hover-text-color);
-
-            border-width: var(--header-navigation-button-hover-border-width);
-            border-style: var(--header-navigation-button-hover-border-style);
-            border-color: var(--header-navigation-button-hover-border-color);
-            border-radius: var(--header-navigation-button-hover-border-radius);
+            border-width: var(--header-navigation-link-hover-border-width);
+            border-style: var(--header-navigation-link-hover-border-style);
+            border-color: var(--header-navigation-link-hover-border-color);
+            border-radius: var(--header-navigation-link-hover-border-radius);
+            font-weight: var(--header-navigation-link-hover-font-weight);
           }
         }
       }

--- a/manon/link-variables.scss
+++ b/manon/link-variables.scss
@@ -3,7 +3,7 @@
 /*----------------------------------------------------------------------------------*/
 :root {
   /* Link */
-  --link-background-color: unset;
+  --link-background-color: transparent;
   --link-text-color: #0000c2;
   --link-hover-text-color: #000088;
 

--- a/manon/navigation-collapsible-menu.scss
+++ b/manon/navigation-collapsible-menu.scss
@@ -136,8 +136,6 @@ button.menu_toggle {
 
 /* Above breakpoint */
 body > header nav {
-  padding: var(--navigation-base-padding, 0 0.5rem);
-
   > div {
     display: flex;
   }


### PR DESCRIPTION
Updated nav styling options and fixed issues found. Added manon docs nav styling.

fix: unexpected behaviour (visited links styling) 
added: Styling options. E.g border-styles and min-height on items.
updated: docs main nav styling

Solves: https://github.com/minvws/nl-rdo-manon/issues/119

Before: 
<img width="1665" alt="Screenshot 2023-03-20 at 18 22 43" src="https://user-images.githubusercontent.com/11405133/226599787-fc310f19-84a3-483d-9a1c-0b3d681f9929.png">

After: 
![Screenshot 2023-03-21 at 13 00 20](https://user-images.githubusercontent.com/11405133/226599908-b5480eac-57dd-4834-a59d-f5d972fa8cf6.png)

