### PR TITLE
Hide elements with hidden attribute

### DIFF
--- a/docs/documentation/components/hidden.html
+++ b/docs/documentation/components/hidden.html
@@ -69,11 +69,12 @@
 
           <section id="example">
             <h2>Voorbeeld</h2>
-            <p>Onderstaand voorbeeld bevat twee paragrafen waarvan er een verborgen wordt.</p>
+            <p>Onderstaand voorbeeld bevat drie paragrafen waarvan er twee verborgen worden.</p>
 
             <div>
               <p class="hidden">Voorbeeld paragraaf 1.</p>
-              <p>Voorbeeld paragraaf 2.</p>
+              <p hidden>Voorbeeld paragraaf 2.</p>
+              <p>Voorbeeld paragraaf 3.</p>
             </div>
 
             <h3>Html-voorbeeld:</h3>
@@ -81,7 +82,8 @@
               <code>
 &lt;div>
   &lt;p class="hidden">Voorbeeld paragraaf 1.&lt;/p>
-  &lt;p>Voorbeeld paragraaf 2.&lt;/p>
+  &lt;p hidden>Voorbeeld paragraaf 2.&lt;/p>
+  &lt;p>Voorbeeld paragraaf 3.&lt;/p>
 &lt;/div>
               </code>
             </pre>

--- a/manon/hidden.scss
+++ b/manon/hidden.scss
@@ -2,6 +2,7 @@
 /*---------------------------------- hidden.scss -----------------------------------*/
 /*----------------------------------------------------------------------------------*/
 
+*[hidden],
 .hidden {
   display: none !important; /* !important added to solve/prevent any specificity issues. */
 }

--- a/manon/notification-paragraph.scss
+++ b/manon/notification-paragraph.scss
@@ -3,7 +3,7 @@
 /*---------------------------------------------------------------*/
 @use "notification-paragraph-variables";
 
-p:not([hidden]) {
+p {
   &.notification,
   &.error,
   &.warning,

--- a/manon/notification-paragraph.scss
+++ b/manon/notification-paragraph.scss
@@ -3,7 +3,7 @@
 /*---------------------------------------------------------------*/
 @use "notification-paragraph-variables";
 
-p {
+p:not([hidden]) {
   &.notification,
   &.error,
   &.warning,


### PR DESCRIPTION
Having an element like:

`<p class="error" role="status" hidden></p>`

Renders:

![image](https://user-images.githubusercontent.com/1367665/230610507-947f981e-6f1f-45f1-bea0-33076240abd3.png)

The current `display: inline-block;` overwrites the browser hidden `display: none;`. With this change the hidden styling is used when an element has the hidden attribute.