### PR TITLE
Fix: Whitespace breaking

### DIFF
--- a/manon/max-line-length-variables.scss
+++ b/manon/max-line-length-variables.scss
@@ -7,9 +7,6 @@
   --max-line-length-word-break: normal;
 
   /* After breakpoint */
-  --max-line-length-breakpoint-hyphens: none;
-  --max-line-length-breakpoint-word-break: var(
-    --max-line-length-word-break,
-    normal
-  );
+  --max-line-length-breakpoint-hyphens: var(--max-line-length-hyphens, auto);
+  --max-line-length-breakpoint-word-break: var(--max-line-length-word-break, normal);
 }


### PR DESCRIPTION
Removed white-space:break-spaces as it was resulting in undesirable behaviour in combination with linters.