### PR TITLE
Fix: Unnecessary white space within links

### DIFF
--- a/manon/link.scss
+++ b/manon/link.scss
@@ -22,7 +22,6 @@ a {
   background-color: var(--link-background-color);
   color: var(--link-text-color, initial);
   cursor: pointer;
-  white-space: break-spaces;
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;

--- a/manon/max-line-length-variables.scss
+++ b/manon/max-line-length-variables.scss
@@ -7,9 +7,6 @@
   --max-line-length-word-break: normal;
 
   /* After breakpoint */
-  --max-line-length-breakpoint-hyphens: none;
-  --max-line-length-breakpoint-word-break: var(
-    --max-line-length-word-break,
-    normal
-  );
+  --max-line-length-breakpoint-hyphens: var(--max-line-length-hyphens);
+  --max-line-length-breakpoint-word-break: var(--max-line-length-word-break);
 }


### PR DESCRIPTION
Removed white-space:break-spaces as it was resulting in undesirable behaviour in combination with linters.