### PR TITLE
Remove extra hidden attribute styling

### DIFF
--- a/manon/filter.scss
+++ b/manon/filter.scss
@@ -4,10 +4,6 @@
 @use "filter-variables";
 
 .filter {
-  > form[hidden] {
-    display: none;
-  }
-
   > div {
     display: flex;
     flex-direction: row;

--- a/manon/table-expando-rows.scss
+++ b/manon/table-expando-rows.scss
@@ -38,10 +38,6 @@ table {
 
 .js-expando-rows-loaded {
   table {
-    tr.expando-row[hidden] {
-      display: none;
-    }
-
     button.expando-button {
       display: inline-flex;
     }


### PR DESCRIPTION
Removed additional styling when hidden attribute is used for expando-row and form withing element containig filter class.

After https://github.com/minvws/nl-rdo-manon/pull/138 this should not be needed.