### PR TITLE
Fix: removed broken hidden attribute

### DIFF
--- a/manon/navigation.js
+++ b/manon/navigation.js
@@ -63,7 +63,6 @@ function makeResponsive(nav, isCondensed) {
 function createMenuButton(ul, openLabel, closeLabel) {
   var button = document.createElement("button");
   button.className = "menu_toggle";
-  button.setAttribute("hidden", "false");
   button.setAttribute("aria-controls", ul.id);
   button.setAttribute("aria-expanded", "false");
 


### PR DESCRIPTION
Fix: removed broken hidden attribute. The state added to the hidden attribute is non-existing so it referred back to its default state which is "hidden". I removed the addition of the hidden attribute since it was redundant as the css hides the button when needed. 