### PR TITLE
fix: link styling including before and states

### DIFF
--- a/manon/footer-variables.scss
+++ b/manon/footer-variables.scss
@@ -18,9 +18,26 @@
 
   /* Links */
   --footer-link-text-color: var(--footer-text-color);
+  --footer-link-before-text-color: var(--footer-link-text-color);
   --footer-link-text-decoration: none;
+
+  /* Links visited */
+  --footer-link-visited-text-color: var(--footer-link-text-color);
+  --footer-link-visited-before-text-color: var(--footer-link-visited-text-color);
+  --footer-link-visited-text-decoration: var(--footer-link-text-decoration);
 
   /* Links hover */
   --footer-link-hover-text-color: var(--footer-link-text-color);
+  --footer-link-hover-before-text-color: var(--footer-link-hover-text-color);
   --footer-link-hover-text-decoration: underline;
+
+  /* Links visited hover */
+  --footer-link-visited-hover-text-color: var(--footer-link-text-color);
+  --footer-link-visited-hover-before-text-color: var(--footer-link-visited-hover-text-color);
+  --footer-link-visited-hover-text-decoration: var(--footer-link-hover-text-decoration);
+  
+  /* Links active */
+  --footer-link-active-text-color: var(--footer-link-text-color);
+  --footer-link-active-before-text-color: --footer-link-active-text-color;
+  --footer-link-active-text-decoration: var(--footer-link-hover-text-decoration);
 }

--- a/manon/footer.scss
+++ b/manon/footer.scss
@@ -35,18 +35,59 @@ body > footer,
     color: var(--footer-text-color);
   }
 
-  a,
-  a:visited {
-    color: var(--footer-link-text-color, inherit);
+  %link-styling {
+    color: var(--footer-link-text-color);
     text-decoration: var(--footer-link-text-decoration);
 
-    &:before,
-    &:hover {
-      color: var(--footer-link-hover-text-color);
+    &:before {
+      color: var(--footer-link-before-text-color);
+    }
+
+    &:active {
+      color: var(--footer-link-active-text-color);
+
+      &:before {
+        color: var(--footer-link-active-before-text-color);
+      }
     }
 
     &:hover {
-      text-decoration: var(--footer-link-hover-text-decoration);
+      color: var(--footer-link-hover-text-color);
+
+      &:before {
+        color: var(--footer-link-hover-before-text-color);
+      }
+    }
+
+    &:visited {
+      color: var(--footer-link-visited-text-color);
+
+      &:before {
+        color: var(--footer-link-visited-before-text-color);
+      }
+
+      &:hover {
+        color: var(--footer-link-visited-hover-text-color);
+
+        &:before {
+          color: var(--footer-link-visited-hover-before-text-color);
+        }
+      }
     }
   }
+
+  a,
+  a:visited {
+    @extend %link-styling;
+  }
+
+  nav,
+  nav h1 {
+		color: var(--footer-link-text-color);
+    text-decoration: var(--footer-link-text-decoration);
+
+		a {
+      @extend %link-styling;
+		}
+	}
 }


### PR DESCRIPTION
fix: link styling including states and before's 

Solves the issue where links were the expected color. But before and states like visited links were not.