### PR TITLE
fix: Removing inherited before elements within nav's where needed

### DIFF
--- a/manon/breadcrumb-bar.scss
+++ b/manon/breadcrumb-bar.scss
@@ -36,6 +36,7 @@
     padding: var(--breadcrumb-bar-list-padding);
     gap: var(--breadcrumb-bar-list-gap);
     color: inherit;
+    background-color: transparent;
 
     li {
       display: flex;
@@ -44,6 +45,10 @@
       align-items: center;
       list-style: none;
       gap: var(--breadcrumb-bar-list-item-gap);
+
+      &:before {
+        display: none; /* Preventing default nav before to show up */
+      }
 
       &:after {
         content: var(--breadcrumb-bar-icon);

--- a/manon/header-navigation.scss
+++ b/manon/header-navigation.scss
@@ -107,6 +107,10 @@ body > header,
         color: var(--header-navigation-list-item-text-color);
         list-style: none;
 
+        &:before {
+          display: none; /* Preventing default nav before to show up */
+        }
+
         &[aria-current="page"] {
         > a {
             @extend %active-link;

--- a/manon/navigation-collapsible-menu.scss
+++ b/manon/navigation-collapsible-menu.scss
@@ -51,6 +51,10 @@ body > header nav.collapsible-menu,
       color: var(--navigation-collapsible-menu-list-collapsed-text-color);
       background-color: var(--navigation-collapsible-menu-list-item-collapsed-background-color);
 
+      &:before {
+        display: none; /* Preventing default nav before to show up */
+      }
+
       &:last-child {
         border-width: var(--navigation-collapsible-menu-list-item-collapsed-last-item-border-width);
       }

--- a/manon/navigation-tabs.scss
+++ b/manon/navigation-tabs.scss
@@ -4,19 +4,17 @@
 @use "navigation-tabs-variables";
 
 nav.tabs {
-  /*flex-wrap: nowrap;*/
-
-  /*> div {
-		display: flex;
-		padding: 0;
-	}*/
-
   ul,
   ol {
     margin-top: 0;
     margin-bottom: 0;
 
     li {
+
+      &:before {
+        display: none; /* Preventing default nav before to show up */
+      }
+      
       a,
       a:visited {
         display: flex;

--- a/manon/navigation-variables.scss
+++ b/manon/navigation-variables.scss
@@ -29,13 +29,13 @@
   --navigation-list-item-list-style: var(--list-base-item-list-style, initial);
 
   /* List item icon */
-  /* --accordion-button-icon-font-family: var(--icon-base-font-family); */
+  --navigation-list-item-icon-display: none; /* Set to initial when using an icon */
   --navigation-list-item-icon-font-family: var(--icon-base-font-family);
   --navigation-list-item-icon-line-height: var(--navigation-list-line-height);
-  --navigation-list-item-icon-content: "";
+  --navigation-list-item-icon-content:  "";
   --navigation-list-item-icon-font-size: var(--navigation-title-font-size);
   --navigation-list-item-icon-padding: 0 0.5rem 0 0;
-
+ 
   /* Links */
     /* Links */
     --navigation-link-text-color: var(--navigation-text-color);

--- a/manon/navigation.scss
+++ b/manon/navigation.scss
@@ -43,6 +43,7 @@ nav {
             font-size: var(--navigation-list-item-icon-font-size, inherit);
             vertical-align: middle;
             padding: var(--navigation-list-item-icon-padding);
+            display: var(--navigation-list-item-icon-display);
         }
 
         a,


### PR DESCRIPTION
fix: Removing inherited before elements within nav's where needed
fix: Some small css clean up's

By adding the option to add icons to the main "nav"-element it gets inherited by all nav's. Some don't need it based on how those elements are used. This pr provides an override for those instances. 