### PR TITLE
Publish as package on GitHub packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  publish:
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,3 +26,27 @@ jobs:
         run: cd manon && pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-github:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish
+        # pnpm checks whether you are on the main branch when running publish,
+        # but github will checkout the tag, so we need to disable the check
+        run: cd manon && pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
npm is limited to one registry per scope. 

When using a @minvws scoped private npm package hosted on GitHub npm registry, npm could not find this package on the GitHub npm registry. With this fix we will also publish the package to this registry.

There is a RFC at npm for this: https://github.com/npm/rfcs/issues/275 and https://github.com/npm/statusboard/issues/340.