### PR TITLE
Fixes height on square and round images

### DIFF
--- a/manon/image-cover.scss
+++ b/manon/image-cover.scss
@@ -8,7 +8,7 @@
   object-position: var(--image-cover-object-position);
   width: 100%;
   max-width: 100%;
-  padding: 0;
+  padding: 0; /* Resetting padding */
   height: 100%;
   max-height: var(--image-cover-max-height);
 }

--- a/manon/image-round.scss
+++ b/manon/image-round.scss
@@ -6,6 +6,7 @@
 /* Image container */
 %image-round-container {
   width: 100%;
+  padding: 0; /* Resetting padding */
   padding-bottom: 100%;
   position: relative;
 }

--- a/manon/image-square.scss
+++ b/manon/image-square.scss
@@ -6,6 +6,7 @@
 /* Image container */
 %image-square-container {
   width: 100%;
+  padding: 0; /* Resetting padding */
   padding-bottom: 100%;
   position: relative;
 }


### PR DESCRIPTION
- Fixes height on square and round images

Padding inherited from layout elements pushed the square images to be too long. This pr solves this issue. 