### PR TITLE
Removed icon classes from help button and use css

### DIFF
--- a/manon/form-help-button-centered-variables.scss
+++ b/manon/form-help-button-centered-variables.scss
@@ -28,7 +28,8 @@
   --form-help-button-background-color: #3f51b5;
 
   /* Button icon */
-  --form-help-button-icon-content: "?";
+  --form-help-button-icon: "?";
+  --form-help-button-icon-expanded: "X";
   --form-help-button-icon-font-size: 0.9rem;
   --form-help-button-icon-font-weight: bold;
 }

--- a/manon/form-help-variables.scss
+++ b/manon/form-help-variables.scss
@@ -32,7 +32,8 @@
   --form-help-button-hover-text-color: var(--form-help-button-text-color);
 
   /* Button icon */
-  --form-help-button-icon-content: "?";
+  --form-help-button-icon: "?";
+  --form-help-button-icon-expanded: "X";
   --form-help-button-icon-font-size: 0.9rem;
   --form-help-button-icon-font-weight: bold;
 

--- a/manon/form-help.js
+++ b/manon/form-help.js
@@ -72,15 +72,8 @@ function collapseExplanation(explanation) {
   var button = document.createElement("button");
   var openLabel = explanation.dataset.openLabel || "Open uitleg";
   var closeLabel = explanation.dataset.closeLabel || "Sluit uitleg";
-  var iconOpenClasses = (
-    explanation.dataset.iconOpenClass || "icon icon-questionmark"
-  ).split(/\s+/);
-  var iconCloseClasses = (
-    explanation.dataset.iconCloseClass || "icon icon-close"
-  ).split(/\s+/);
 
   button.classList.add("help-button");
-  button.classList.add.apply(button.classList, iconOpenClasses);
   button.type = "button";
   button.setAttribute("aria-expanded", "false");
   button.setAttribute("aria-controls", explanation.id);
@@ -88,14 +81,6 @@ function collapseExplanation(explanation) {
   button.addEventListener("click", function toggleExpanded() {
     var expand = button.getAttribute("aria-expanded") === "false";
     button.setAttribute("aria-expanded", expand ? "true" : "false");
-    button.classList.remove.apply(
-      button.classList,
-      expand ? iconOpenClasses : iconCloseClasses
-    );
-    button.classList.add.apply(
-      button.classList,
-      expand ? iconCloseClasses : iconOpenClasses
-    );
     button.innerText = expand ? closeLabel : openLabel;
     if (expand) {
       explanation.classList.remove("collapsed");

--- a/manon/form-help.scss
+++ b/manon/form-help.scss
@@ -49,12 +49,18 @@ form.help {
       }
 
       &:before {
-        content: var(--form-help-button-icon-content);
+        content: var(--form-help-button-icon);
         font-family: var(--form-help-button-icon-font-family, inherit);
         line-height: var(--form-help-button-icon-line-height);
         font-size: var(--form-help-button-icon-font-size, inherit);
         font-weight: var(--form-help-button-icon-font-weight, inherit);
         vertical-align: middle;
+      }
+
+      &[aria-expanded="true"] {
+        &:before {
+          content: var(--form-help-button-icon-expanded);
+        }
       }
     }
 

--- a/manon/form-help.scss
+++ b/manon/form-help.scss
@@ -33,6 +33,7 @@ form.help {
       border-color: var(--form-help-button-border-color);
       border-radius: var(--form-help-button-border-radius);
 
+      gap: 0;
       margin: 0;
       min-width: 0;
       width: var(--form-help-button-width);
@@ -76,7 +77,6 @@ form.help {
     gap: 0;
 
     .help-button {
-      gap: 0;
       margin: 0;
 
       &:before {


### PR DESCRIPTION
Based on aria-expanded set the expanded content.

Not expended:
![image](https://user-images.githubusercontent.com/1367665/235710981-bb1f545e-ba15-4906-87c8-de50fe0517c9.png)

Expended:
![image](https://user-images.githubusercontent.com/1367665/235711057-3c0878f9-de02-40eb-a65d-9c5b09a00137.png)

After removing icon classes the help-button missed `gap: 0`.  So added that.
![image](https://user-images.githubusercontent.com/1367665/235713445-78319f83-4000-4cf7-b23d-cd88e7555b28.png)

