### PR TITLE
Set form textarea styling based on form input styling

### DIFF
--- a/manon/form-textarea-variables.scss
+++ b/manon/form-textarea-variables.scss
@@ -8,9 +8,9 @@
   --form-textarea-padding: 0.75rem;
   /* --form-textarea-font-size: ; */
   /* --form-textarea-font-family: ; */
-  --form-textarea-text-color: var(--form-input-text-color);
-  --form-textarea-background-color: var(--form-input-background-color);
-  --form-textarea-border-width: var(--form-input-border-width);
-  --form-textarea-border-style: var(--form-input-border-style);
-  --form-textarea-border-color: var(--form-input-border-color);
+  --form-textarea-text-color: var(--form-input-text-color, #000);
+  --form-textarea-background-color: var(--form-input-background-color, #fff);
+  --form-textarea-border-width: var(--form-input-border-width, 1px);
+  --form-textarea-border-style: var(--form-input-border-style, solid);
+  --form-textarea-border-color: var(--form-input-border-color, #000);
 }

--- a/manon/form-textarea-variables.scss
+++ b/manon/form-textarea-variables.scss
@@ -8,9 +8,9 @@
   --form-textarea-padding: 0.75rem;
   /* --form-textarea-font-size: ; */
   /* --form-textarea-font-family: ; */
-  /* --form-textarea-text-color: ; */
-  --form-textarea-background-color: white;
-  --form-textarea-border-width: 1px;
-  --form-textarea-border-style: solid;
-  --form-textarea-border-color: black;
+  --form-textarea-text-color: var(--form-input-text-color);
+  --form-textarea-background-color: var(--form-input-background-color);
+  --form-textarea-border-width: var(--form-input-border-width);
+  --form-textarea-border-style: var(--form-input-border-style);
+  --form-textarea-border-color: var(--form-input-border-color);
 }


### PR DESCRIPTION
Updated form-textarea-variables to use the form-input-variables for background-color, text-color and border.

Do we need to set default for input?

https://github.com/minvws/nl-rdo-manon/blob/b715090c9d05c31f10673125493099b30719a1f2/manon/form-input-variables.scss#L5-L18
