### PR TITLE
Fix: Inconsistent classname for radio buttons

### DIFF
--- a/docs/documentation/components/form-horizontal-view-test.html
+++ b/docs/documentation/components/form-horizontal-view-test.html
@@ -586,7 +586,7 @@
             <h5>Visueel voorbeeld:</h5>
 
             <form action="" method="post" class="horizontal-view">
-              <div class="radio-button">
+              <div class="radio">
                 <input
                   type="radio"
                   id="radio-example"
@@ -600,7 +600,7 @@
             <pre>
               <code>
 &lt;form action="" method="post" class="horizontal-view">
-  &lt;div class="radio-button">
+  &lt;div class="radio">
     &lt;input
       type="radio"
       id="radio-example"
@@ -616,7 +616,7 @@
             <h5>Visueel voorbeeld:</h5>
 
             <form action="" method="post" class="horizontal-view">
-              <div class="radio-button required">
+              <div class="radio required">
                 <div>
                   <span class="nota-bene">Dit veld is verplicht</span>
 
@@ -633,7 +633,7 @@
             <pre>
               <code>
 &lt;form action="" method="post" class="horizontal-view">
-  &lt;div class="radio-button required">
+  &lt;div class="radio required">
     &lt;div>
       &lt;span class="nota-bene">Dit veld is verplicht&lt;/span>
 
@@ -652,7 +652,7 @@
             <h5>Visueel voorbeeld:</h5>
 
             <form action="" method="post" class="horizontal-view">
-              <div class="radio-button">
+              <div class="radio">
                 <input type="radio" id="radio-example-disabled" name="radio uitgeschakeld" disabled>
                 <label for="radio-example-disabled">Uitgeschakelde radio-button</label>
               </div>
@@ -662,7 +662,7 @@
             <pre>
               <code>
 &lt;form action="" method="post" class="horizontal-view">
-  &lt;div class="radio-button">
+  &lt;div class="radio">
     &lt;input type="radio" id="radio-example-disabled" name="radio uitgeschakeld" disabled>
     &lt;label for="radio-example-disabled">Uitgeschakelde radio-button&lt;/label>
   &lt;/div>
@@ -917,7 +917,7 @@
 
               <fieldset>
                 <legend>radio-buttons</legend>
-                <div class="radio-button">
+                <div class="radio">
                   <input
                     type="radio"
                     id="radio-example-default-5"
@@ -926,7 +926,7 @@
                   <label for="radio-example-default-5">Radio button</label>
                 </div>
 
-                <div class="radio-button required">
+                <div class="radio required">
                   <div>
                     <span class="nota-bene">Dit veld is verplicht</span>
 
@@ -937,7 +937,7 @@
                   </div>
                 </div>
 
-                <div class="radio-button">
+                <div class="radio">
                   <input type="radio" id="radio-example-disabled-fieldset" name="voorbeeld uitgeschakeld radio-button binnen fieldset" disabled>
                   <label for="radio-example-disabled-fieldset">uitgeschakelde radio-button</label>
                 </div>
@@ -1051,7 +1051,7 @@
 
   &lt;fieldset>
     &lt;legend>radio-buttons&lt;/legend>
-    &lt;div class="radio-button">
+    &lt;div class="radio">
       &lt;input
         type="radio"
         id="radio-example-default-5"
@@ -1060,7 +1060,7 @@
       &lt;label for="radio-example-default-5">Radio button&lt;/label>
     &lt;/div>
 
-    &lt;div class="radio-button required">
+    &lt;div class="radio required">
       &lt;div>
         &lt;span class="nota-bene">Dit veld is verplicht&lt;/span>
 
@@ -1071,7 +1071,7 @@
       &lt;/div>
     &lt;/div>
 
-    &lt;div class="radio-button">
+    &lt;div class="radio">
       &lt;input type="radio" id="radio-example-disabled-fieldset" name="voorbeeld uitgeschakeld radio-button binnen fieldset" disabled>
       &lt;label for="radio-example-disabled-fieldset">uitgeschakelde radio-button&lt;/label>
     &lt;/div>

--- a/manon/form-horizontal-view-fieldset.scss
+++ b/manon/form-horizontal-view-fieldset.scss
@@ -86,7 +86,7 @@ form.horizontal-view {
     }
 
     .checkbox,
-    .radio-button {
+    .radio {
       margin-left: var(--form-horizontal-view-label-max-width);
       width: var(--form-horizontal-view-input-max-width);
 

--- a/manon/form-horizontal-view.scss
+++ b/manon/form-horizontal-view.scss
@@ -69,7 +69,7 @@ form.horizontal-view {
       }
     }
 
-    &.radio-button {
+    &.radio {
       gap: var(--form-radio-margin-right);
 
       %horizontal-view-radio,


### PR DESCRIPTION
Fix: Incosistent classname for radio buttons

Breaking change: class="radio-button" is now class="radio"