### PR TITLE
Fix content wrappers to only style direct div childs

### DIFF
--- a/manon/footer-content-wrapper.scss
+++ b/manon/footer-content-wrapper.scss
@@ -4,7 +4,7 @@
 @use "footer-content-wrapper-variables";
 
 footer {
-    div {
+    > div {
         display: flex;
         flex-direction: var(--footer-content-wrapper-flex-direction);
         justify-content: var(--footer-content-wrapper-justify-content);

--- a/manon/section-content-wrapper.scss
+++ b/manon/section-content-wrapper.scss
@@ -4,7 +4,7 @@
 @use "section-content-wrapper-variables";
 
 main section {
-  div {
+  > div {
     display: flex;
     flex-direction: var(--section-content-wrapper-flex-direction);
     justify-content: var(--section-content-wrapper-justify-content);


### PR DESCRIPTION
Fixes https://github.com/minvws/nl-rdo-manon/issues/242

Content wrapper should only set styling of the direct div child.

Currently:

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/46e7930b-63b7-4b8d-a29a-bceff4793548)

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/a6788395-870c-4167-b7bb-39ac0d0a04e4)

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/c5af826e-eb2d-4bdd-b077-6538c855f9e9)

After this pr:

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/30238799-415b-4094-9e2a-790d0b5f0da6)
