### PR TITLE
Fix header navigation link to be applied on links within nav

### DIFF
--- a/manon/header-navigation-link-focus.scss
+++ b/manon/header-navigation-link-focus.scss
@@ -4,7 +4,7 @@
 @use "header-navigation-link-focus-variables";
 @use "mixins/link";
 
-%header-navigation-link-hover-styling {
+%header-navigation-link-focus-styling {
   a {
     &:focus,
     &.focus /* Testing purposes */
@@ -17,13 +17,13 @@
 body > header,
 %header-navigation-style {
   nav {
-    @extend %header-navigation-link-hover-styling;
-  }
+    @extend %header-navigation-link-focus-styling;
 
-  ul,
-  ol {
-    li {
-      @extend %header-navigation-link-hover-styling;
+    ul,
+    ol {
+      li {
+        @extend %header-navigation-link-focus-styling;
+      }
     }
   }
 }

--- a/manon/header-navigation-link-hover.scss
+++ b/manon/header-navigation-link-hover.scss
@@ -18,12 +18,12 @@ body > header,
 %header-navigation-style {
   nav {
     @extend %header-navigation-link-hover-styling;
-  }
 
-  ul,
-  ol {
-    li {
-      @extend %header-navigation-link-hover-styling;
+    ul,
+    ol {
+      li {
+        @extend %header-navigation-link-hover-styling;
+      }
     }
   }
 }


### PR DESCRIPTION
The `ul, ol li selector was outside the nav element. This _ofcourse_ caused problems with other items like the language selector.

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/c0bebe7b-2205-44e3-8a2d-63a7a0e8b935)


![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/754446f0-123e-48f8-ae73-1dd0b2343142)
