### PR TITLE
Remove sidemenu content container padding

### DIFF
--- a/manon/sidemenu-variables.scss
+++ b/manon/sidemenu-variables.scss
@@ -15,12 +15,6 @@
   /* Reserve space for the button */
   --sidemenu-main-max-height: 90vh;
 
-  /* Content container (top level div, section or article) */
-  --sidemenu-content-container-padding-top: 0;
-  --sidemenu-content-container-padding-right: 0;
-  --sidemenu-content-container-padding-bottom: 0;
-  --sidemenu-content-container-padding-left: 0;
-
   /* Nav inside side menu */
   --sidemenu-nav-background-color: transparent;
   --sidemenu-nav-border-width: 0 1px 0 0;

--- a/manon/sidemenu.scss
+++ b/manon/sidemenu.scss
@@ -27,10 +27,6 @@ main.sidemenu {
   >section {
     display: flex;
     flex-direction: column;
-    padding-top: var(--sidemenu-content-container-padding-top);
-    padding-right: var(--sidemenu-content-container-padding-right);
-    padding-bottom: var(--sidemenu-content-container-padding-bottom);
-    padding-left: var(--sidemenu-content-container-padding-left);
     box-sizing: border-box;
 
     @media (min-width: $sidemenu-breakpoint) {


### PR DESCRIPTION
It overriden the default article, div and section padding, thats why it is removed.

Now it is possible to set a background color on an article and the color will be full width.

![image](https://github.com/minvws/nl-rdo-manon/assets/1367665/31ff4cd2-1a6b-42df-af9a-cb1ac03df35f)
