### PR TITLE
Fix: Removed 0 padding from collapsible-toggle

### DIFF
--- a/manon/mixins/collapsible.scss
+++ b/manon/mixins/collapsible.scss
@@ -3,7 +3,7 @@
 /*---------------------------------------------------------------*/
 
 @mixin collapsible {
-    
+
     &.collapsed {
         padding: 0;
         gap: 0;
@@ -15,7 +15,6 @@
         button.collapsible-toggle  {
             display: flex;
             max-height: 100%;
-            padding: 0;
 
             + .collapsing-element {
                 display: flex;


### PR DESCRIPTION
Now we have text on the collapsible-toggle the 0 padding is not reasonable anymore. By removing this is uses the default button padding.

If we need custom padding for the collapsible-toggle, we can add that in the future.