### PR TITLE
fix: .visually-hidden (VoiceOver on macOS)

### DIFF
--- a/manon/visually-hidden.scss
+++ b/manon/visually-hidden.scss
@@ -5,10 +5,8 @@
   clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px);
   white-space: nowrap;
   overflow: hidden;
-  width: 0;
-  height: 0;
-  max-width: 0;
-  max-height: 0;
+  width: 1px;
+  height: 1px;
 
   /* Overwriting any specifics that might have been set.    */
   /* !important is used here to solve any specificity issues */


### PR DESCRIPTION
This is an attempt at addressing an issue with `.visually-hidden`, using VoiceOver (Safari 16.6, macOS 13.5).

The `width: 0`, `height: 0`, `max-width: 0` and `max-height: 0` cause VoiceOver not to read `.visually-hidden` elements in some contexts, including table `<caption>`s.

Omitting the `max-width` and `max-height` and setting `width` and `height` to `1px` seems to address this issue without anything becoming visible.

This requires further testing.