### PR TITLE
Fixes issue with border on states on tabs

### DIFF
--- a/manon/tabs-variables.scss
+++ b/manon/tabs-variables.scss
@@ -2,10 +2,7 @@
 /*------------------------------ tabs-variables.scss -------------------------------*/
 /*----------------------------------------------------------------------------------*/
 :root {
-  --tabs-border-top-width: 0;
-  --tabs-border-right-width: 0;
-  --tabs-border-bottom-width: 1px;
-  --tabs-border-left-width: 0;
+  --tabs-border-width: 0 0 1px 0;
   --tabs-border-style: solid;
   --tabs-border-color: #808080;
   --tabs-background-color: transparent;

--- a/manon/tabs.scss
+++ b/manon/tabs.scss
@@ -51,10 +51,7 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  border-top-width: var(--tabs-border-top-width);
-  border-right-width: var(--tabs-border-right-width);
-  border-bottom-width: var(--tabs-border-bottom-width);
-  border-left-width: var(--tabs-border-left-width);
+  border-width: var(--tabs-border-width);
   border-style: var(--tabs-border-style);
   border-color: var(--tabs-border-color);
   gap: var(--tabs-gap);


### PR DESCRIPTION
Fixes issue with border on states on tabs where the border was set too specific on the default state. Brought the specificity down by setting the border-width instead of border-top-width for example.