### PR TITLE
Add pnpm to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Maintain dependencies for pnpm
+  - package-ecosystem: "pnpm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: "weekly"
 
   # Maintain dependencies for pnpm
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Since june it is possible to keep pnpm dependencies up to date with Dependabot.

https://github.blog/changelog/2023-06-12-dependabot-version-updates-now-supports-pnpm/