### PR TITLE
Fixes alignment issues with buttons on wider screens

### DIFF
--- a/manon/accordion-variables.scss
+++ b/manon/accordion-variables.scss
@@ -6,44 +6,40 @@
   --accordion-gap: 0.5rem; /* Space between accordion items */
 
   /* Button */
+  --accordion-button-display: flex;
   --accordion-button-padding: 0 1rem;
   --accordion-button-justify-content: flex-start;
-  /*  --accordion-button-font-size: ; */
-  /* --accordion-button-font-weight: ; */
-  /* --accordion-button-line-height: ; */
+  --accordion-button-font-size: var(--application-base-font-size);
+  --accordion-button-font-weight: var(--application-base-font-weight);
+  --accordion-button-line-height: var(--application-base-line-height);
   --accordion-button-background-color: var(--button-base-background-color);
   --accordion-button-text-color: var(--button-base-text-color);
 
   /* Button icon */
   /* Side menu button before */
   --accordion-button-icon-before-font-size: 1rem;
-  /* --accordion-button-icon-before-font-weight: ; */
-  /* --accordion-button-icon-before-white-space: ; */
-
   --accordion-button-icon-after-font-size: 1rem;
-  /* --accordion-button-icon-after-font-weight: ; */
-  /* --accordion-button-icon-after-white-space: ; */
 
   /* add content within "", this could be text or a unicode for an icon*/
   /* Choose before or after */
   --accordion-button-icon-font-family: var(--icon-font-family);
 
   /* content on the button when the menu is collapsed */
-  /* --accordion-button-icon-before-open-content: "v"; */
+  --accordion-button-icon-before-open-content: none;
   --accordion-button-icon-after-open-content: "v";
 
   /* content on the button when the menu is expanded */
-  /* --accordion-button-icon-before-close-content: "^"; */
-  /* --accordion-button-icon-font-family: var(--icon-font-family); */
+  --accordion-button-icon-before-close-content: none;
+  --accordion-button-icon-font-family: var(--icon-font-family);
   --accordion-button-icon-after-close-content: "^";
   --accordion-button-icon-after-margin-left: auto;
 
   /* Content */
   --accordion-content-padding: 2rem 1rem;
   --accordion-content-gap: 1rem;
-  /* --accordion-content-font-size: ; */
-  /* --accordion-content-font-weight: ; */
-  /* --accordion-content-line-height: ; */
+  --accordion-content-font-size: var(--application-base-font-size);
+  --accordion-content-font-weight: var(--application-base-font-weight);
+  --accordion-content-line-height: var(--application-base-line-height);
   --accordion-content-border-width: 1px;
   --accordion-content-border-style: solid;
   --accordion-content-border-color: #ccc;

--- a/manon/accordion.scss
+++ b/manon/accordion.scss
@@ -9,6 +9,7 @@
 }
 
 %accordion-button {
+  display: var(--accordion-button-display);
   width: 100%;
   padding: var(--accordion-button-padding);
   font-size: var(--accordion-font-size, inherit);
@@ -95,16 +96,12 @@ section.accordion {
         content: var(--accordion-button-icon-before-open-content, none);
         font-family: var(--accordion-button-icon-font-family, inherit);
         font-size: var(--accordion-button-icon-before-font-size);
-        font-weight: var(--accordion-button-icon-before-font-weight);
-        white-space: var(--accordion-button-icon-before-white-space);
       }
 
       &:after {
         content: var(--accordion-button-icon-after-open-content, none);
         font-family: var(--accordion-button-icon-font-family, inherit);
         font-size: var(--accordion-button-icon-after-font-size);
-        font-weight: var(--accordion-button-icon-after-font-weight);
-        white-space: var(--accordion-button-icon-after-white-space);
         margin-left: auto;
       }
 

--- a/manon/button-base.scss
+++ b/manon/button-base.scss
@@ -129,23 +129,19 @@ input[type="reset"] {
     pointer-events: none;
   }
 
+  /* Buttons can not be flex containers as it gives issues with line breaks */
+  /* It does work on wider screens. So using flex box where possible. */
   @media (min-width: $breakpoint) {
     min-width: var(--button-base-min-width);
+    display: flex;
   }
 }
 
 /* Buttons can not be flex containers as it gives issues with line breaks */
-/* It does work on wider screens and on other elements. */
-/* So using flex box where possible. */
+/* It does work on other elements. So using flex box where possible. */
 a.button,
 input[type="button"],
 input[type="submit"],
 input[type="reset"] {
   display: flex;
-}
-
-@media (min-width: $breakpoint) {
-  button {
-    display: flex;
-  }
 }

--- a/manon/button-base.scss
+++ b/manon/button-base.scss
@@ -134,11 +134,18 @@ input[type="reset"] {
   }
 }
 
-/* Buttons can not be flex containers */
-/* But these elements can. So using flex box where possible. */
+/* Buttons can not be flex containers as it gives issues with line breaks */
+/* It does work on wider screens and on other elements. */
+/* So using flex box where possible. */
 a.button,
 input[type="button"],
 input[type="submit"],
 input[type="reset"] {
   display: flex;
+}
+
+@media (min-width: $breakpoint) {
+  button {
+    display: flex;
+  }
 }


### PR DESCRIPTION
Chose to use display flex on wider screens as the known issues with flexbox only occur on smaller screens. 

- Fixes button alignment on wider screens
- Fixes accordion button alignment
- Fills in empty variables on accordion.

Solves: 
https://github.com/minvws/nl-rdo-manon/issues/368 