### PR TITLE
Removes header styling options from expando rows 

### DIFF
--- a/docs/documentation/components/table-expando-row.html
+++ b/docs/documentation/components/table-expando-row.html
@@ -330,36 +330,7 @@
                     <td>Openklapbare cel - td</td>
                     <td>CSS</td>
                   </tr>
-
-                  <tr>
-                    <td>--expando-rows-table-content-title-font-size</td>
-                    <td><a href="../variables.html#font-size">font-size</a></td>
-                    <td>1.25rem</td>
-                    <td>Titel binnen de openklapbare cel - h1</td>
-                    <td>CSS</td>
-                  </tr>
-                  <tr>
-                    <td>--expando-rows-table-content-title-font-weight</td>
-                    <td><a href="../variables.html#font-weight">font-weight</a></td>
-                    <td>bolder</td>
-                    <td>Titel binnen de openklapbare cel - h1</td>
-                    <td>CSS</td>
-                  </tr>
-
-                  <tr>
-                    <td>--expando-rows-table-content-subtitle-font-size</td>
-                    <td><a href="../variables.html#font-size">font-size</a></td>
-                    <td>1rem</td>
-                    <td>Subtitel binnen de openklapbare cel - h2</td>
-                    <td>CSS</td>
-                  </tr>
-                  <tr>
-                    <td>--expando-rows-table-content-subtitle-font-weight</td>
-                    <td><a href="../variables.html#font-weight">font-weight</a></td>
-                    <td>bolder</td>
-                    <td>Subtitel binnen de openklapbare cel - h2</td>
-                    <td>CSS</td>
-                  </tr>
+                  
                   <tr>
                     <td>$breakpoint</td>
                     <td><a href="../variables.html#breakpoints">Breekpunt</a></td>

--- a/manon/table-expando-rows-variables.scss
+++ b/manon/table-expando-rows-variables.scss
@@ -6,14 +6,6 @@
   --expando-rows-table-cell-background-color: #e5e5e5;
   --expando-rows-table-cell-padding: 2rem 1rem;
 
-  /* Table exando content title */
-  --expando-rows-table-content-title-font-size: 1.25rem;
-  --expando-rows-table-content-title-font-weight: bolder;
-
-  /* Table exando content subtitle */
-  --expando-rows-table-content-subtitle-font-size: 1rem;
-  --expando-rows-table-content-subtitle-font-weight: bolder;
-
   /* After breakpoint */
   --expando-rows-table-cell-after-breakpoint-padding: 2rem 3rem;
 

--- a/manon/table-expando-rows.scss
+++ b/manon/table-expando-rows.scss
@@ -22,16 +22,6 @@ table {
       @media (min-width: $breakpoint) {
         padding: var(--expando-rows-table-cell-after-breakpoint-padding);
       }
-
-      h1 {
-        font-size: var(--expando-rows-table-content-title-font-size);
-        font-weight: var(--expando-rows-table-content-title-font-weight);
-      }
-
-      h2 {
-        font-size: var(--expando-rows-table-content-subtitle-font-size);
-        font-weight: var(--expando-rows-table-content-subtitle-font-weight);
-      }
     }
   }
 }


### PR DESCRIPTION
Removes header styling options from expando rows as that behaviour is now covered by headings-base-set. And setting the variables within the element will block the usage of the classes as set up in headings-set.