### PR TITLE
fix: filters.js aria-controls target

### DIFF
--- a/manon/filters.js
+++ b/manon/filters.js
@@ -52,8 +52,8 @@ function initFilterToggle(filterToggle) {
     hideLabel = filterToggle.dataset.hideFiltersLabel || "Verberg filters";
     showLabel = filterToggle.innerText;
   }
-  ensureElementHasId(filter);
-  filterToggle.setAttribute("aria-controls", filter.id);
+  ensureElementHasId(form);
+  filterToggle.setAttribute("aria-controls", form.id);
   if (expanded) {
     filterToggle.setAttribute("aria-expanded", "true");
   } else {


### PR DESCRIPTION
This PR changes which element forms.js uses as the `aria-controls` target. Instead of the grandparent of the button (`.filter`), it now targets the actual `form` that the button controls.
