### PR TITLE
chore(navigation-link-button): added visited state styling for the navigation link button

### DIFF
--- a/manon/header-navigation-button-states.scss
+++ b/manon/header-navigation-button-states.scss
@@ -10,6 +10,14 @@ body > header,
 .page-header,
 %header-navigation-style {
   nav {
+    a.button {
+      &:visited,
+        /* Testing purposes */
+      &.visited {
+        @include link.link-and-icon-styling("header-navigation-button-");
+      }
+    }
+
     button,
     a.button,
     input[type="button"],


### PR DESCRIPTION
Links can have visited styling. For a link that we display as a button there was not visited styling configured.

This adds this adds the visited styling to be displayed.

Because button does not have a visited state this configures the styling to use the default button styling.