### PR TITLE
fix(docs): use {base} in all hrefs

### DIFF
--- a/docs/src/routes/(docs)/components/+page.svelte
+++ b/docs/src/routes/(docs)/components/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import NavLink from "$lib/NavLink.svelte";
 </script>
 
@@ -29,22 +30,22 @@
         <nav aria-labelledby="layout-text-heading">
           <h3 id="layout-text-heading">Tekst</h3>
           <ul>
-            <li><a href="./components/font">Lettertype toevoegen</a></li>
+            <li><a href="{base}/components/font">Lettertype toevoegen</a></li>
             <li>
               <strong>Titels</strong>
               <ul>
-                <li><a href="./components/headings">Titels</a></li>
-                <li><a href="./components/heading-base-set">Titel basisset</a></li>
+                <li><a href="{base}/components/headings">Titels</a></li>
+                <li><a href="{base}/components/heading-base-set">Titel basisset</a></li>
               </ul>
             </li>
             <li>
               <strong>Tekstweergaven</strong>
               <ul>
-                <li><a href="./components/body-text-set">Body text set</a></li>
-                <li><a href="./components/paragraph">Paragraaf</a></li>
-                <li><a href="./components/emphasized">Benadrukte weergave</a></li>
-                <li><a href="./components/de-emphasized">Subtielere weergave</a></li>
-                <li><a href="./components/nota-bene">Nota bene</a></li>
+                <li><a href="{base}/components/body-text-set">Body text set</a></li>
+                <li><a href="{base}/components/paragraph">Paragraaf</a></li>
+                <li><a href="{base}/components/emphasized">Benadrukte weergave</a></li>
+                <li><a href="{base}/components/de-emphasized">Subtielere weergave</a></li>
+                <li><a href="{base}/components/nota-bene">Nota bene</a></li>
               </ul>
             </li>
           </ul>
@@ -54,36 +55,36 @@
           <h3 id="colors-heading">Kleuren</h3>
           <ul>
             <li>
-              <a href="./components/branding-colors">Kleurensets</a>
+              <a href="{base}/components/branding-colors">Kleurensets</a>
               <ul>
                 <li>
                   <strong>Finn</strong> Set met 2,3 of 5 kleuren.
                   <ul>
-                    <li><a href="./components/finn-small">Klein (twee kleuren)</a></li>
-                    <li><a href="./components/finn-medium">Middel (drie kleuren)</a></li>
-                    <li><a href="./components/finn-large">Groot (vijf kleuren)</a></li>
+                    <li><a href="{base}/components/finn-small">Klein (twee kleuren)</a></li>
+                    <li><a href="{base}/components/finn-medium">Middel (drie kleuren)</a></li>
+                    <li><a href="{base}/components/finn-large">Groot (vijf kleuren)</a></li>
                   </ul>
                 </li>
                 <li>
                   <strong>Spot</strong> Set met hoofdkleuren en accentkleuren.
                   <ul>
                     <li>
-                      <a href="./components/spot-mini"
+                      <a href="{base}/components/spot-mini"
                         >Spot mini (twee hoofdkleuren en een accentkleur)</a
                       >
                     </li>
                     <li>
-                      <a href="./components/spot-small"
+                      <a href="{base}/components/spot-small"
                         >Spot klein (twee hoofdkleuren en twee accentkleuren)</a
                       >
                     </li>
                     <li>
-                      <a href="./components/spot-medium"
+                      <a href="{base}/components/spot-medium"
                         >Spot middel (twee hoofdkleuren en drie accentkleuren)</a
                       >
                     </li>
                     <li>
-                      <a href="./components/spot-large"
+                      <a href="{base}/components/spot-large"
                         >Spot groot (twee hoofdkleuren en vijf accentkleuren)</a
                       >
                     </li>
@@ -104,26 +105,26 @@
         <nav aria-labelledby="layout-base">
           <h3 id="layout-base">Basis-elementen</h3>
           <ul>
-            <li><a href="./components/main"><code>main</code></a></li>
-            <li><a href="./components/section">Sectie - <code>section</code></a></li>
-            <li><a href="./components/article">Artikel - <code>article</code></a></li>
-            <li><a href="./components/div"><code>div</code></a></li>
-            <li><a href="./components/footer"><code>footer</code></a></li>
+            <li><a href="{base}/components/main"><code>main</code></a></li>
+            <li><a href="{base}/components/section">Sectie - <code>section</code></a></li>
+            <li><a href="{base}/components/article">Artikel - <code>article</code></a></li>
+            <li><a href="{base}/components/div"><code>div</code></a></li>
+            <li><a href="{base}/components/footer"><code>footer</code></a></li>
           </ul>
         </nav>
 
         <nav aria-labelledby="layout-exceptions">
           <h3 id="layout-exceptions">Uitzonderingsweergaven</h3>
           <ul>
-            <li><a href="./components/layout-authentication">Authentication</a></li>
-            <li><a href="./components/layout-one-third-two-thirds">Eenderde tweederde</a></li>
-            <li><a href="./components/layout-two-thirds-one-third">Tweederde eenderde</a></li>
-            <li><a href="./components/layout-fifty-fifty">50/50</a></li>
-            <li><a href="./components/layout-centered">Gecentreerd</a></li>
-            <li><a href="./components/layout-form">layout-form</a></li>
-            <li><a href="./components/layout-column-2">Twee kolommen</a></li>
-            <li><a href="./components/layout-column-3">Drie kolommen</a></li>
-            <li><a href="./components/layout-column-4">Vier kolommen</a></li>
+            <li><a href="{base}/components/layout-authentication">Authentication</a></li>
+            <li><a href="{base}/components/layout-one-third-two-thirds">Eenderde tweederde</a></li>
+            <li><a href="{base}/components/layout-two-thirds-one-third">Tweederde eenderde</a></li>
+            <li><a href="{base}/components/layout-fifty-fifty">50/50</a></li>
+            <li><a href="{base}/components/layout-centered">Gecentreerd</a></li>
+            <li><a href="{base}/components/layout-form">layout-form</a></li>
+            <li><a href="{base}/components/layout-column-2">Twee kolommen</a></li>
+            <li><a href="{base}/components/layout-column-3">Drie kolommen</a></li>
+            <li><a href="{base}/components/layout-column-4">Vier kolommen</a></li>
           </ul>
         </nav>
       </div>
@@ -141,21 +142,21 @@
             <p>Componenten die direct aan html-elementen gerelateerd zijn.</p>
 
             <ul>
-              <li><a href="./components/button">Knoppen - <code>button</code></a></li>
-              <li><a href="./components/forms">Formulieren - <code>form</code></a></li>
-              <li><a href="./components/link">Link <code>a</code></a></li>
-              <li><a href="./components/table">Tabellen - <code>table</code></a></li>
+              <li><a href="{base}/components/button">Knoppen - <code>button</code></a></li>
+              <li><a href="{base}/components/forms">Formulieren - <code>form</code></a></li>
+              <li><a href="{base}/components/link">Link <code>a</code></a></li>
+              <li><a href="{base}/components/table">Tabellen - <code>table</code></a></li>
               <li>
-                <a href="./components/description-list">Description list - <code>dl</code></a>
+                <a href="{base}/components/description-list">Description list - <code>dl</code></a>
               </li>
               <li>
                 Afbeeldingen - <code>img</code>
                 <ul>
-                  <li><a href="./components/logo">Logo</a></li>
-                  <li><a href="./components/icons">Iconen</a></li>
-                  <li><a href="./components/image-cover">Cover-afbeelding</a></li>
-                  <li><a href="./components/image-round">Ronde afbeelding</a></li>
-                  <li><a href="./components/image-square">Vierkante afbeelding</a></li>
+                  <li><a href="{base}/components/logo">Logo</a></li>
+                  <li><a href="{base}/components/icons">Iconen</a></li>
+                  <li><a href="{base}/components/image-cover">Cover-afbeelding</a></li>
+                  <li><a href="{base}/components/image-round">Ronde afbeelding</a></li>
+                  <li><a href="{base}/components/image-square">Vierkante afbeelding</a></li>
                 </ul>
               </li>
             </ul>
@@ -166,19 +167,19 @@
           <nav aria-labelledby="other-components-heading" id="other-components">
             <h3 id="other-components-heading">Overige componenten</h3>
             <ul>
-              <li><a href="./components/accordion">Accordeon</a></li>
-              <li><a href="./components/filter">Filter</a></li>
-              <li><a href="./components/header-navigation">Header</a></li>
-              <li><a href="./components/login-meta">Ingelogd als</a></li>
-              <li><a href="./components/collapsible">Inklapbaar component</a></li>
-              <li><a href="./components/card">Kaart</a></li>
-              <li><a href="./components/breadcrumb-bar">Kruimelpad - breadcrumb-bar</a></li>
-              <li><a href="./components/pagination">Paginering</a></li>
-              <li><a href="./components/tag">Tag</a></li>
-              <li><a href="./components/tabs">Tabbladen</a></li>
-              <li><a href="./components/tiles">Tegelweergave</a></li>
-              <li><a href="./components/sidemenu">Zijmenu</a></li>
-              <li><a href="./components/language-selector">Taalselectie</a></li>
+              <li><a href="{base}/components/accordion">Accordeon</a></li>
+              <li><a href="{base}/components/filter">Filter</a></li>
+              <li><a href="{base}/components/header-navigation">Header</a></li>
+              <li><a href="{base}/components/login-meta">Ingelogd als</a></li>
+              <li><a href="{base}/components/collapsible">Inklapbaar component</a></li>
+              <li><a href="{base}/components/card">Kaart</a></li>
+              <li><a href="{base}/components/breadcrumb-bar">Kruimelpad - breadcrumb-bar</a></li>
+              <li><a href="{base}/components/pagination">Paginering</a></li>
+              <li><a href="{base}/components/tag">Tag</a></li>
+              <li><a href="{base}/components/tabs">Tabbladen</a></li>
+              <li><a href="{base}/components/tiles">Tegelweergave</a></li>
+              <li><a href="{base}/components/sidemenu">Zijmenu</a></li>
+              <li><a href="{base}/components/language-selector">Taalselectie</a></li>
             </ul>
           </nav>
 
@@ -186,10 +187,10 @@
             <h4 id="notifications-heading">Notificaties</h4>
             <ul>
               <li>
-                <a href="./components/message-counter">Notificatie-teller</a>
+                <a href="{base}/components/message-counter">Notificatie-teller</a>
               </li>
               <li>
-                <a href="./components/notifications">Notificaties</a>
+                <a href="{base}/components/notifications">Notificaties</a>
               </li>
             </ul>
           </nav>
@@ -204,7 +205,7 @@
         <h3 id="accessibility-heading">Toegankelijkheid</h3>
         <ul>
           <li>
-            <a href="./components/max-line-length">Maximale regellengte</a>
+            <a href="{base}/components/max-line-length">Maximale regellengte</a>
           </li>
         </ul>
       </nav>
@@ -217,25 +218,25 @@
         <h3 id="helper-classes-heading">Helper-classes</h3>
         <ul>
           <li>
-            <a href="./components/horizontal-view">Horizontaal uitgelijnd</a>
+            <a href="{base}/components/horizontal-view">Horizontaal uitgelijnd</a>
           </li>
           <li>
-            <a href="./components/layout-centered">Gecentreerd</a>
+            <a href="{base}/components/layout-centered">Gecentreerd</a>
           </li>
           <li>
-            <a href="./components/horizontal-center">Horizontaal gecentreerd</a>
+            <a href="{base}/components/horizontal-center">Horizontaal gecentreerd</a>
           </li>
           <li>
-            <a href="./components/focus-only">Alleen zichtbaar "on focus"</a>
+            <a href="{base}/components/focus-only">Alleen zichtbaar "on focus"</a>
           </li>
           <li>
-            <a href="./components/horizontal-scroll">Horizontale scroll</a>
+            <a href="{base}/components/horizontal-scroll">Horizontale scroll</a>
           </li>
           <li>
-            <a href="./components/nowrap">nowrap</a>
+            <a href="{base}/components/nowrap">nowrap</a>
           </li>
           <li>
-            <a href="./components/hidden">Verbergen - <dfn>hidden</dfn></a>
+            <a href="{base}/components/hidden">Verbergen - <dfn>hidden</dfn></a>
           </li>
         </ul>
       </nav>

--- a/docs/src/routes/(docs)/components/accordion/+page.svelte
+++ b/docs/src/routes/(docs)/components/accordion/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -41,7 +42,7 @@
               <li>
                 Voeg het bijbehorende Javascript-bestand toe aan het project. Voor meer informatie
                 zie:
-                <a href="../add-js">JavaScript toevoegen</a>.
+                <a href="{base}/add-js">JavaScript toevoegen</a>.
               </li>
             </ul>
           </li>
@@ -307,7 +308,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -327,27 +328,27 @@
           <li>
             Accordeon list
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
           <li>
             <code>button</code>
             <ul>
-              <li><a href="../variables#padding">padding</a></li>
+              <li><a href="{base}/variables#padding">padding</a></li>
               <li>
-                <a href="../variables#justify-content">justify-content</a>
+                <a href="{base}/variables#justify-content">justify-content</a>
               </li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
               <li>
-                <a href="../variables#font-weight">font-weight</a>
-              </li>
-              <li>
-                <a href="../variables#line-height">line-height</a>
+                <a href="{base}/variables#font-weight">font-weight</a>
               </li>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#line-height">line-height</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li>
+                <a href="{base}/variables#background-color">background-color</a>
+              </li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
           <li>
@@ -357,15 +358,15 @@
               <li>
                 <code>:before</code>
                 <ul>
-                  <li><a href="../variables#icon">icon</a></li>
+                  <li><a href="{base}/variables#icon">icon</a></li>
                 </ul>
               </li>
               <li>
                 <code>:after</code>
                 <ul>
-                  <li><a href="../variables#icon">icon</a></li>
+                  <li><a href="{base}/variables#icon">icon</a></li>
                   <li>
-                    <a href="../variables#margin-left">margin-left</a>
+                    <a href="{base}/variables#margin-left">margin-left</a>
                   </li>
                 </ul>
               </li>
@@ -374,28 +375,28 @@
           <li>
             Content
             <ul>
-              <li><a href="../variables#padding">padding</a></li>
-              <li><a href="../variables#gap">gap</a></li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#padding">padding</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
               <li>
-                <a href="../variables#font-weight">font-weight</a>
+                <a href="{base}/variables#font-weight">font-weight</a>
               </li>
               <li>
-                <a href="../variables#line-height">line-height</a>
+                <a href="{base}/variables#line-height">line-height</a>
               </li>
               <li>
-                <a href="../variables#border-width">border-width</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
         </ul>
@@ -403,7 +404,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./accordion-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/accordion-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/application-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/application-base/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -66,7 +67,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >
         </p>
         <h4>CSS-voorbeeld:</h4>
@@ -84,7 +85,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -131,7 +132,7 @@
               <tr>
                 <th rowspan="2" scope="rowgroup">application-base</th>
                 <td>--application-base-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>-</td>
                 <td>#fff</td>
                 <td>-</td>
@@ -139,7 +140,7 @@
 
               <tr>
                 <td>--application-base-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>var(--text-set-text-color)</td>
                 <td>-</td>
@@ -148,7 +149,7 @@
               <tr>
                 <th rowspan="2" scope="rowgroup">application-base-tint-1</th>
                 <td>--application-base-tint-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>-</td>
                 <td>#f5f5f5</td>
                 <td>-</td>
@@ -156,7 +157,7 @@
 
               <tr>
                 <td>--application-base-tint-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#000</td>
                 <td>-</td>
@@ -173,7 +174,7 @@
 
               <tr>
                 <td>--application-base-accent-color-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#fff</td>
                 <td>-</td>
@@ -189,7 +190,7 @@
 
               <tr>
                 <td>--application-base-accent-color-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#000</td>
                 <td>-</td>
@@ -205,7 +206,7 @@
 
               <tr>
                 <td>--application-base-accent-color-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#000</td>
                 <td>-</td>
@@ -221,7 +222,7 @@
 
               <tr>
                 <td>--application-base-accent-color-focus-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#000</td>
                 <td>-</td>
@@ -237,7 +238,7 @@
 
               <tr>
                 <td>--application-base-accent-color-selected-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#000</td>
                 <td>-</td>
@@ -254,7 +255,7 @@
 
               <tr>
                 <td>--cta-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>-</td>
                 <td>#fff</td>
                 <td>-</td>
@@ -263,7 +264,7 @@
               <tr>
                 <th>application-base-font-family</th>
                 <td>--application-base-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>-</td>
                 <td>var(--text-set-font-family)</td>
                 <td>-</td>
@@ -272,7 +273,7 @@
               <tr>
                 <th>application-base-font-size</th>
                 <td>--application-base-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>-</td>
                 <td>var(--text-set-font-size)</td>
                 <td>-</td>
@@ -281,7 +282,7 @@
               <tr>
                 <th>application-base-line-height</th>
                 <td>--application-base-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>-</td>
                 <td>var(--text-set-line-height)</td>
                 <td>-</td>
@@ -290,7 +291,7 @@
               <tr>
                 <th>application-base-font-weight</th>
                 <td>--application-base-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>-</td>
                 <td>var(--text-set-font-weight)</td>
                 <td>-</td>
@@ -299,7 +300,7 @@
               <tr>
                 <th>application-base-text-align</th>
                 <td>--application-base-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>-</td>
                 <td>var(--text-set-text-align)</td>
                 <td>-</td>
@@ -308,7 +309,7 @@
               <tr>
                 <th>application-base-padding</th>
                 <td>--application-base-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>-</td>
                 <td>1.5rem</td>
                 <td>-</td>
@@ -317,7 +318,7 @@
               <tr>
                 <th>application-base-border-radius</th>
                 <td>--application-base-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>-</td>
                 <td>0</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/article-content-wrapper-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/article-content-wrapper-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -37,7 +38,7 @@
       <h2>Gebruikte componenten</h2>
       <p>
         Voor meer informatie over importeren en instellen van componenten. Zie: <a
-          href="../import-styling">Componenten gebruiken en styling toevoegen</a
+          href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
         >
       </p>
 

--- a/docs/src/routes/(docs)/components/article-content-wrapper/+page.svelte
+++ b/docs/src/routes/(docs)/components/article-content-wrapper/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -106,7 +107,7 @@
             <tbody>
               <tr>
                 <td>--article-content-wrapper-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -114,7 +115,7 @@
 
               <tr>
                 <td>--article-content-wrapper-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -122,7 +123,7 @@
 
               <tr>
                 <td>--article-content-wrapper-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -130,7 +131,7 @@
 
               <tr>
                 <td>--article-content-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--content-gap)</td>
                 <td>-</td>
                 <td>-</td>
@@ -138,7 +139,7 @@
 
               <tr>
                 <td>--article-content-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--content-padding-top)</td>
                 <td>-</td>
                 <td>-</td>
@@ -146,7 +147,7 @@
 
               <tr>
                 <td>--article-content-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -154,7 +155,7 @@
 
               <tr>
                 <td>--article-content-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -162,7 +163,7 @@
 
               <tr>
                 <td>--article-content-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -170,7 +171,7 @@
 
               <tr>
                 <td>--article-content-wrapper-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--content-max-width)</td>
                 <td>-</td>
                 <td>-</td>
@@ -210,7 +211,7 @@
               <a href="article-content-wrapper-test">Sectie content wrapper test</a> Testpagina met
               de content gegroepeerd binnen <code>article</code>'s met een content wrapper.
             </li>
-            <li><a href="./article">Article</a> Content zonder content wrapper.</li>
+            <li><a href="{base}/components/article">Article</a> Content zonder content wrapper.</li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/article-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/article-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -32,7 +33,7 @@
     <h2>Gebruikte componenten</h2>
     <p>
       Voor meer informatie over importeren en instellen van componenten. Zie: <a
-        href="../import-styling">Componenten gebruiken en styling toevoegen</a
+        href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
       >
     </p>
 

--- a/docs/src/routes/(docs)/components/article/+page.svelte
+++ b/docs/src/routes/(docs)/components/article/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -72,7 +73,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -104,7 +105,7 @@
             <tbody>
               <tr>
                 <td>--article-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -112,7 +113,7 @@
 
               <tr>
                 <td>--article-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -120,7 +121,7 @@
 
               <tr>
                 <td>--article-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -128,7 +129,7 @@
 
               <tr>
                 <td>--article-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -136,7 +137,7 @@
 
               <tr>
                 <td>--article-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -144,7 +145,7 @@
 
               <tr>
                 <td>--article-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -152,7 +153,7 @@
 
               <tr>
                 <td>--article-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -160,7 +161,7 @@
 
               <tr>
                 <td>--article-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -168,7 +169,7 @@
 
               <tr>
                 <td>--article-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -208,7 +209,7 @@
               <a href="article-test">Article test</a> Testpagina met de content gegroepeerd binnen
               <code>article</code>'s.
             </li>
-            <li><a href="./article-content-wrapper">Article content wrapper</a></li>
+            <li><a href="{base}/components/article-content-wrapper">Article content wrapper</a></li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/body-text-set/+page.svelte
+++ b/docs/src/routes/(docs)/components/body-text-set/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -42,7 +43,7 @@
               <li>
                 Pas de stijlkeuzes toe waar nodig. De stijlkeuzes kunnen door middel van variabelen
                 binnen de CSS toegepast worden. Voor meer informatie hierover zie <a
-                  href="../use-css-variable">CSS-variabelen gebruiken</a
+                  href="{base}/use-css-variable">CSS-variabelen gebruiken</a
                 >.
               </li>
             </ul>
@@ -106,7 +107,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -139,7 +140,7 @@
             <tbody>
               <tr>
                 <td>--text-set-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td
                   >-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Roboto Sans", "Noto
                   Sans", sans-serif</td
@@ -150,7 +151,7 @@
 
               <tr>
                 <td>--text-set-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -158,7 +159,7 @@
 
               <tr>
                 <td>--text-set-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>normal</td>
                 <td>-</td>
                 <td>-</td>
@@ -166,7 +167,7 @@
 
               <tr>
                 <td>--text-set-strong-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>bold</td>
                 <td>-</td>
                 <td>-</td>
@@ -174,7 +175,7 @@
 
               <tr>
                 <td>--text-set-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>1.5</td>
                 <td>-</td>
                 <td>-</td>
@@ -182,7 +183,7 @@
 
               <tr>
                 <td>--text-set-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>#000</td>
                 <td>-</td>
                 <td>-</td>
@@ -190,7 +191,7 @@
 
               <tr>
                 <td>--text-set-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>left</td>
                 <td>-</td>
                 <td>-</td>
@@ -215,7 +216,7 @@
               <tr>
                 <th rowspan="5" scope="rowgroup">body text small</th>
                 <td>--body-text-small-set-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0.8rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -223,7 +224,7 @@
 
               <tr>
                 <td>--body-text-small-set-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--text-set-font-weight)</td>
                 <td>-</td>
                 <td>-</td>
@@ -231,7 +232,7 @@
 
               <tr>
                 <td>--body-text-small-set-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--text-set-line-height)</td>
                 <td>-</td>
                 <td>-</td>
@@ -239,7 +240,7 @@
 
               <tr>
                 <td>--body-text-small-set-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>#696969</td>
                 <td>-</td>
                 <td>-</td>
@@ -247,7 +248,7 @@
 
               <tr>
                 <td>--text-set-small-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>var(--text-set-text-align)</td>
                 <td>-</td>
                 <td>-</td>
@@ -256,7 +257,7 @@
               <tr>
                 <th rowspan="5" scope="rowgroup">body text medium</th>
                 <td>--body-text-medium-set-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0.8rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -264,7 +265,7 @@
 
               <tr>
                 <td>--body-text-medium-set-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--text-set-font-weight)</td>
                 <td>-</td>
                 <td>-</td>
@@ -272,7 +273,7 @@
 
               <tr>
                 <td>--body-text-medium-set-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--text-set-line-height)</td>
                 <td>-</td>
                 <td>-</td>
@@ -280,7 +281,7 @@
 
               <tr>
                 <td>--body-text-medium-set-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>#696969</td>
                 <td>-</td>
                 <td>-</td>
@@ -288,7 +289,7 @@
 
               <tr>
                 <td>--text-set-medium-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>var(--text-set-text-align)</td>
                 <td>-</td>
                 <td>-</td>
@@ -297,7 +298,7 @@
               <tr>
                 <th rowspan="5" scope="rowgroup">body text large</th>
                 <td>--body-text-large-set-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0.8rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -305,7 +306,7 @@
 
               <tr>
                 <td>--body-text-large-set-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--text-set-font-weight)</td>
                 <td>-</td>
                 <td>-</td>
@@ -313,7 +314,7 @@
 
               <tr>
                 <td>--body-text-large-set-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--text-set-line-height)</td>
                 <td>-</td>
                 <td>-</td>
@@ -321,7 +322,7 @@
 
               <tr>
                 <td>--body-text-large-set-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>#696969</td>
                 <td>-</td>
                 <td>-</td>
@@ -329,7 +330,7 @@
 
               <tr>
                 <td>--text-set-large-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>var(--text-set-text-align)</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/branding-colors/+page.svelte
+++ b/docs/src/routes/(docs)/components/branding-colors/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
 
@@ -26,9 +27,9 @@
             <h2>Finn</h2>
             <p>Set met gelijkwaardige kleuren</p>
             <ul>
-              <li><a href="./finn-small">Klein (twee kleuren)</a></li>
-              <li><a href="./finn-medium">Middel (drie kleuren)</a></li>
-              <li><a href="./finn-large">Groot (vijf kleuren)</a></li>
+              <li><a href="{base}/components/finn-small">Klein (twee kleuren)</a></li>
+              <li><a href="{base}/components/finn-medium">Middel (drie kleuren)</a></li>
+              <li><a href="{base}/components/finn-large">Groot (vijf kleuren)</a></li>
             </ul>
           </nav>
 
@@ -36,15 +37,15 @@
             <h2>Spot</h2>
             <p>Huisstijlkleuren met accentkleuren</p>
             <ul>
-              <li><a href="./spot-mini">Spot mini (twee hoofdkleuren en een accentkleur)</a></li>
+              <li><a href="{base}/components/spot-mini">Spot mini (twee hoofdkleuren en een accentkleur)</a></li>
               <li>
-                <a href="./spot-small">Spot klein (twee hoofdkleuren en twee accentkleuren)</a>
+                <a href="{base}/components/spot-small">Spot klein (twee hoofdkleuren en twee accentkleuren)</a>
               </li>
               <li>
-                <a href="./spot-medium">Spot middel (twee hoofdkleuren en drie accentkleuren)</a>
+                <a href="{base}/components/spot-medium">Spot middel (twee hoofdkleuren en drie accentkleuren)</a>
               </li>
               <li>
-                <a href="./spot-large">Spot groot (twee hoofdkleuren en vijf accentkleuren)</a>
+                <a href="{base}/components/spot-large">Spot groot (twee hoofdkleuren en vijf accentkleuren)</a>
               </li>
             </ul>
           </nav>

--- a/docs/src/routes/(docs)/components/breadcrumb-bar-example/+page.svelte
+++ b/docs/src/routes/(docs)/components/breadcrumb-bar-example/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -49,9 +50,9 @@
 <nav class="breadcrumb-bar">
     <div>
         <ul>
-            <li><a href="../components">Componenten</a></li>
+            <li><a href="{base}/components">Componenten</a></li>
             <li>
-                <a href="./breadcrumb-bar" aria-current="page">Kruimelpad - breadcrumb-bar</a>
+                <a href="{base}/components/breadcrumb-bar" aria-current="page">Kruimelpad - breadcrumb-bar</a>
             </li>
         </ul>
     </div>
@@ -69,9 +70,9 @@
     <nav aria-label="Hoofdnavigatie">
         <div>
             <ul>
-                <li><a href="../../index">Home</a></li>
-                <li><a href="../components">Componenten</a></li>
-                <li><a href="../documentation">Documentatie</a></li>
+                <li><a href="{base}/../index">Home</a></li>
+                <li><a href="{base}/components">Componenten</a></li>
+                <li><a href="{base}/documentation">Documentatie</a></li>
             </ul>
         </div>
     </nav>
@@ -79,9 +80,9 @@
     <nav class="breadcrumb-bar">
         <div>
             <ul>
-                <li><a href="../components">Componenten</a></li>
+                <li><a href="{base}/components">Componenten</a></li>
                 <li>
-                    <a href="./breadcrumb-bar" aria-current="page">Kruimelpad - breadcrumb-bar</a>
+                    <a href="{base}/components/breadcrumb-bar" aria-current="page">Kruimelpad - breadcrumb-bar</a>
                 </li>
             </ul>
         </div>

--- a/docs/src/routes/(docs)/components/breadcrumb-bar/+page.svelte
+++ b/docs/src/routes/(docs)/components/breadcrumb-bar/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -58,7 +59,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>

--- a/docs/src/routes/(docs)/components/button-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-base/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Import scss-file</h3>
         <Code
@@ -110,133 +111,133 @@
               <tr>
                 <th>--button-base-flex</th>
                 <td>--button-base-flex</td>
-                <td><a href="../variables#display">display</a></td>
+                <td><a href="{base}/variables#display">display</a></td>
                 <td>inline-flex</td>
               </tr>
 
               <tr>
                 <th>--button-base-gap</th>
                 <td>--button-base-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-padding-top</th>
                 <td>--button-base-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.25rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-padding-right</th>
                 <td>--button-base-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>1rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-padding-bottom</th>
                 <td>--button-base-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.25rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-padding-left</th>
                 <td>--button-base-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>1rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-justify-content</th>
                 <td>--button-base-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>center</td>
               </tr>
 
               <tr>
                 <th>--button-base-min-width</th>
                 <td>--button-base-min-width</td>
-                <td><a href="../variables#min-width">min-width</a></td>
+                <td><a href="{base}/variables#min-width">min-width</a></td>
                 <td>8rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-min-height</th>
                 <td>--button-base-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>2.75rem</td>
               </tr>
 
               <tr>
                 <th>--button-base-background-color</th>
                 <td>--button-base-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-accent-color)</td>
               </tr>
 
               <tr>
                 <th>--button-base-text-color</th>
                 <td>--button-base-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--application-base-accent-color-text-color)</td>
               </tr>
 
               <tr>
                 <th>--button-base-border-width</th>
                 <td>--button-base-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>none</td>
               </tr>
 
               <tr>
                 <th>--button-base-border-style</th>
                 <td>--button-base-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>unset</td>
               </tr>
 
               <tr>
                 <th>--button-base-border-color</th>
                 <td>--button-base-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>transparent</td>
               </tr>
 
               <tr>
                 <th>--button-base-font-size</th>
                 <td>--button-base-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--application-base-font-size)</td>
               </tr>
 
               <tr>
                 <th>--button-base-line-height</th>
                 <td>--button-base-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--application-base-line-height)</td>
               </tr>
 
               <tr>
                 <th>--button-base-font-weight</th>
                 <td>--button-base-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--application-base-font-weight)</td>
               </tr>
 
               <tr>
                 <th>--button-base-text-decoration</th>
                 <td>--button-base-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>none</td>
               </tr>
 
               <tr>
                 <th>--button-base-border-radius</th>
                 <td>--button-base-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>var(--application-base-border-radius)</td>
               </tr>
             </tbody>
@@ -246,7 +247,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./button-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/button-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-call-to-action-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-call-to-action-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -67,7 +68,7 @@
 
         <h3>Link als knop</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-call-to-action-test" class="button cta">Lorem ipsum</a>
+        <a href="{base}/components/button-call-to-action-test" class="button cta">Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -79,7 +80,7 @@
 
         <h3>Link als knop: disabled</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-call-to-action-test" class="button cta" disabled>Lorem ipsum</a>
+        <a href="{base}/components/button-call-to-action-test" class="button cta" disabled>Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -92,25 +93,25 @@
         <h4>States</h4>
         <ul>
           <li>
-            <a href="./button-call-to-action-test" class="button cta focus">Focus</a>
+            <a href="{base}/components/button-call-to-action-test" class="button cta focus">Focus</a>
           </li>
           <li>
-            <a href="./button-call-to-action-test" class="button cta active">Active</a>
+            <a href="{base}/components/button-call-to-action-test" class="button cta active">Active</a>
           </li>
           <li>
-            <a href="./button-call-to-action-test" class="button cta visited">Visited</a>
+            <a href="{base}/components/button-call-to-action-test" class="button cta visited">Visited</a>
           </li>
           <li>
-            <a href="./button-call-to-action-test" class="button cta hover">Hover</a>
+            <a href="{base}/components/button-call-to-action-test" class="button cta hover">Hover</a>
           </li>
           <li>
-            <a href="./button-call-to-action-test" class="button cta selected">Selected</a>
+            <a href="{base}/components/button-call-to-action-test" class="button cta selected">Selected</a>
           </li>
         </ul>
 
         <h3>Link als knop: met een afbeelding</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-call-to-action-test" class="button cta"
+        <a href="{base}/components/button-call-to-action-test" class="button cta"
           >Lorem ipsum <img src="$img/cat.svg" /></a
         >
 

--- a/docs/src/routes/(docs)/components/button-call-to-action/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-call-to-action/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -84,7 +85,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over het importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -99,7 +100,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./button-call-to-action-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/button-call-to-action-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-container-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-container-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -85,7 +86,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-container/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-container/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -68,7 +69,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -103,55 +104,55 @@
             <tbody>
               <tr>
                 <td>--button-container-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>row</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">button-container</td>
               </tr><tr>
                 <td>--button-container-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>center</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-flex-wrap</td>
-                <td><a href="../variables#flex-wrap">flex-wrap</a></td>
+                <td><a href="{base}/variables#flex-wrap">flex-wrap</a></td>
                 <td>wrap</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-medium)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-container-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
@@ -183,7 +184,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./button-container-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/button-container-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-destructive-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-destructive-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -66,7 +67,7 @@
 
         <h3>Link als knop</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-destructive-test" class="button destructive">Lorem ipsum</a>
+        <a href="{base}/components/button-destructive-test" class="button destructive">Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -78,7 +79,7 @@
 
         <h3>Link als knop: disabled</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-destructive-test" class="button destructive" disabled>Lorem ipsum</a>
+        <a href="{base}/components/button-destructive-test" class="button destructive" disabled>Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -91,22 +92,22 @@
         <h4>States</h4>
         <ul>
           <li>
-            <a href="./button-destructive-test" class="button destructive focus">Focus</a>
+            <a href="{base}/components/button-destructive-test" class="button destructive focus">Focus</a>
           </li>
           <li>
-            <a href="./button-destructive-test" class="button destructive active">Active</a>
+            <a href="{base}/components/button-destructive-test" class="button destructive active">Active</a>
           </li>
           <li>
-            <a href="./button-destructive-test" class="button destructive visited">Visited</a>
+            <a href="{base}/components/button-destructive-test" class="button destructive visited">Visited</a>
           </li>
           <li>
-            <a href="./button-destructive-test" class="button destructive hover">Hover</a>
+            <a href="{base}/components/button-destructive-test" class="button destructive hover">Hover</a>
           </li>
         </ul>
 
         <h3>Link als knop: met een afbeelding</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-destructive-test" class="button destructive"
+        <a href="{base}/components/button-destructive-test" class="button destructive"
           >Lorem ipsum <img src="$img/cat.svg" /></a
         >
 

--- a/docs/src/routes/(docs)/components/button-destructive/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-destructive/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -88,32 +89,32 @@
             Knop, hover, active, focus.
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
-              </li>
-              <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-radius">border-radius</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#outline-style">outline-style</a>
+                <a href="{base}/variables#border-radius">border-radius</a>
               </li>
               <li>
-                <a href="../variables#outline-color">outline-color</a>
+                <a href="{base}/variables#outline-style">outline-style</a>
               </li>
               <li>
-                <a href="../variables#outline-width">outline-width</a>
+                <a href="{base}/variables#outline-color">outline-color</a>
               </li>
               <li>
-                <a href="../variables#outline-offset">outline-offset</a>
+                <a href="{base}/variables#outline-width">outline-width</a>
+              </li>
+              <li>
+                <a href="{base}/variables#outline-offset">outline-offset</a>
               </li>
             </ul>
           </li>
@@ -122,7 +123,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./button-destructive-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/button-destructive-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-ghost-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-ghost-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -66,7 +67,7 @@
 
         <h3>Link als knop</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-ghost-test" class="button ghost">Lorem ipsum</a>
+        <a href="{base}/components/button-ghost-test" class="button ghost">Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -78,7 +79,7 @@
 
         <h3>Link als knop: disabled</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-ghost-test" class="button ghost" disabled>Lorem ipsum</a>
+        <a href="{base}/components/button-ghost-test" class="button ghost" disabled>Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -91,22 +92,22 @@
         <h4>States</h4>
         <ul>
           <li>
-            <a href="./button-ghost-test" class="button ghost focus">Focus</a>
+            <a href="{base}/components/button-ghost-test" class="button ghost focus">Focus</a>
           </li>
           <li>
-            <a href="./button-ghost-test" class="button ghost active">Active</a>
+            <a href="{base}/components/button-ghost-test" class="button ghost active">Active</a>
           </li>
           <li>
-            <a href="./button-ghost-test" class="button ghost visited">Visited</a>
+            <a href="{base}/components/button-ghost-test" class="button ghost visited">Visited</a>
           </li>
           <li>
-            <a href="./button-ghost-test" class="button ghost hover">Hover</a>
+            <a href="{base}/components/button-ghost-test" class="button ghost hover">Hover</a>
           </li>
         </ul>
 
         <h3>Link als knop: met een afbeelding</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-ghost-test" class="button ghost">Lorem ipsum <img src="$img/cat.svg" /></a
+        <a href="{base}/components/button-ghost-test" class="button ghost">Lorem ipsum <img src="$img/cat.svg" /></a
         >
 
         <h4>HTML-voorbeeld:</h4>

--- a/docs/src/routes/(docs)/components/button-ghost/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-ghost/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -88,32 +89,32 @@
             Knop, hover, active, focus.
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
-              </li>
-              <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-radius">border-radius</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#outline-style">outline-style</a>
+                <a href="{base}/variables#border-radius">border-radius</a>
               </li>
               <li>
-                <a href="../variables#outline-color">outline-color</a>
+                <a href="{base}/variables#outline-style">outline-style</a>
               </li>
               <li>
-                <a href="../variables#outline-width">outline-width</a>
+                <a href="{base}/variables#outline-color">outline-color</a>
               </li>
               <li>
-                <a href="../variables#outline-offset">outline-offset</a>
+                <a href="{base}/variables#outline-width">outline-width</a>
+              </li>
+              <li>
+                <a href="{base}/variables#outline-offset">outline-offset</a>
               </li>
             </ul>
           </li>
@@ -122,7 +123,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./button-ghost-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/button-ghost-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/button-icon-only/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-icon-only/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -25,7 +26,7 @@
           </li>
           <li>
             Voeg de class van het gewenste icoon toe op de knop. Voor meer informatie zie:
-            <a href="./icons">Iconen</a>.
+            <a href="{base}/components/icons">Iconen</a>.
           </li>
         </ol>
 
@@ -55,7 +56,7 @@
         <h2><code>button</code> met <code>img</code></h2>
         <h3>Visuele weergave:</h3>
 
-        <button href="./button-icon" class="icon-only">
+        <button href="{base}/components/button-icon" class="icon-only">
           Lorem ipsum <img src="$img/cat.svg" alt="Kat" />
         </button>
 
@@ -63,14 +64,14 @@
         <Code
           language="html"
           code={`
-<button href="./button-icon" class="icon-only">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></button>
+<button href="{base}/components/button-icon" class="icon-only">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></button>
 `}
         />
 
         <h2>Link als knop met <code>img</code></h2>
         <h3>Visuele weergave:</h3>
 
-        <a href="./button-icon" class="button icon-only"
+        <a href="{base}/components/button-icon" class="button icon-only"
           >Lorem ipsum <img src="$img/cat.svg" alt="Kat" /></a
         >
 
@@ -78,7 +79,7 @@
         <Code
           language="html"
           code={`
-<a href="./button-icon" class="button icon-only">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></a>
+<a href="{base}/components/button-icon" class="button icon-only">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></a>
 `}
         />
       </section>
@@ -90,32 +91,32 @@
             Knop, hover, active, focus.
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
-              </li>
-              <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-radius">border-radius</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#outline-style">outline-style</a>
+                <a href="{base}/variables#border-radius">border-radius</a>
               </li>
               <li>
-                <a href="../variables#outline-color">outline-color</a>
+                <a href="{base}/variables#outline-style">outline-style</a>
               </li>
               <li>
-                <a href="../variables#outline-width">outline-width</a>
+                <a href="{base}/variables#outline-color">outline-color</a>
               </li>
               <li>
-                <a href="../variables#outline-offset">outline-offset</a>
+                <a href="{base}/variables#outline-width">outline-width</a>
+              </li>
+              <li>
+                <a href="{base}/variables#outline-offset">outline-offset</a>
               </li>
             </ul>
           </li>

--- a/docs/src/routes/(docs)/components/button-icon/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-icon/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -25,7 +26,7 @@
           </li>
           <li>
             Voeg de class van het gewenste icoon toe op de knop. Voor meer informatie zie:
-            <a href="./icons">Iconen</a>.
+            <a href="{base}/components/icons">Iconen</a>.
           </li>
         </ol>
 
@@ -55,7 +56,7 @@
         <h2><code>button</code> met <code>img</code></h2>
         <h3>Visuele weergave:</h3>
 
-        <button href="./button-icon" class="icon">
+        <button href="{base}/components/button-icon" class="icon">
           Lorem ipsum <img src="$img/cat-white.svg" alt="Kat" />
         </button>
 
@@ -63,14 +64,14 @@
         <Code
           language="html"
           code={`
-<button href="./button-icon" class="icon">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></button>
+<button href="{base}/components/button-icon" class="icon">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></button>
 `}
         />
 
         <h2>Link als knop met <code>img</code></h2>
         <h3>Visuele weergave:</h3>
 
-        <a href="./button-icon" class="button icon"
+        <a href="{base}/components/button-icon" class="button icon"
           >Lorem ipsum <img src="$img/cat-white.svg" alt="Kat" /></a
         >
 
@@ -78,7 +79,7 @@
         <Code
           language="html"
           code={`
-<a href="./button-icon" class="button icon">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></a>
+<a href="{base}/components/button-icon" class="button icon">Lorem ipsum <img src="path/to/img.svg" alt="Kat"></a>
 `}
         />
       </section>
@@ -90,32 +91,32 @@
             Knop, hover, active, focus.
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
-              </li>
-              <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-radius">border-radius</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#outline-style">outline-style</a>
+                <a href="{base}/variables#border-radius">border-radius</a>
               </li>
               <li>
-                <a href="../variables#outline-color">outline-color</a>
+                <a href="{base}/variables#outline-style">outline-style</a>
               </li>
               <li>
-                <a href="../variables#outline-width">outline-width</a>
+                <a href="{base}/variables#outline-color">outline-color</a>
               </li>
               <li>
-                <a href="../variables#outline-offset">outline-offset</a>
+                <a href="{base}/variables#outline-width">outline-width</a>
+              </li>
+              <li>
+                <a href="{base}/variables#outline-offset">outline-offset</a>
               </li>
             </ul>
           </li>

--- a/docs/src/routes/(docs)/components/button-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -67,7 +68,7 @@
 
         <h3>Link als knop</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-test" class="button">Lorem ipsum</a>
+        <a href="{base}/components/button-test" class="button">Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -79,7 +80,7 @@
 
         <h3>Link als knop: disabled</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-test" class="button" disabled>Lorem ipsum</a>
+        <a href="{base}/components/button-test" class="button" disabled>Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -92,25 +93,25 @@
         <h4>States</h4>
         <ul>
           <li>
-            <a href="./button-test" class="button focus">Focus</a>
+            <a href="{base}/components/button-test" class="button focus">Focus</a>
           </li>
           <li>
-            <a href="./button-test" class="button active">Active</a>
+            <a href="{base}/components/button-test" class="button active">Active</a>
           </li>
           <li>
-            <a href="./button-test" class="button visited">Visited</a>
+            <a href="{base}/components/button-test" class="button visited">Visited</a>
           </li>
           <li>
-            <a href="./button-test" class="button hover">Hover</a>
+            <a href="{base}/components/button-test" class="button hover">Hover</a>
           </li>
           <li>
-            <a href="./button-test" class="button selected">Selected</a>
+            <a href="{base}/components/button-test" class="button selected">Selected</a>
           </li>
         </ul>
 
         <h3>Link als knop: met een afbeelding</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./button-test" class="button">Lorem ipsum <img src="$img/cat.svg" /></a>
+        <a href="{base}/components/button-test" class="button">Lorem ipsum <img src="$img/cat.svg" /></a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code

--- a/docs/src/routes/(docs)/components/button-to-top/+page.svelte
+++ b/docs/src/routes/(docs)/components/button-to-top/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -79,7 +80,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -110,7 +111,7 @@
             <tbody>
               <tr>
                 <td>--button-to-top-position</td>
-                <td><a href="../variables#position">position</a></td>
+                <td><a href="{base}/variables#position">position</a></td>
                 <td>fixed</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">to-top</td>
@@ -118,119 +119,119 @@
 
               <tr>
                 <td>--button-to-top-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-accent-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-text-color</td>
-                <td><a href="../variables#color">color</a></td>
+                <td><a href="{base}/variables#color">color</a></td>
                 <td>var(--application-base-accent-color-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-bottom</td>
-                <td><a href="../variables#bottom">bottom</a></td>
+                <td><a href="{base}/variables#bottom">bottom</a></td>
                 <td>1rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-right</td>
-                <td><a href="../variables#right">right</a></td>
+                <td><a href="{base}/variables#right">right</a></td>
                 <td>1rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-left</td>
-                <td><a href="../variables#left">left</a></td>
+                <td><a href="{base}/variables#left">left</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>2.75rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>2.75rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>var(--button-to-top-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-min-width</td>
-                <td><a href="../variables#min-width">min-width</a></td>
+                <td><a href="{base}/variables#min-width">min-width</a></td>
                 <td>var(--button-to-top-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>50%</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-hover-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-accent-color-hover)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-hover-text-color</td>
-                <td><a href="../variables#color">text-color</a></td>
+                <td><a href="{base}/variables#color">text-color</a></td>
                 <td>var(--application-base-accent-color-hover-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--button-to-top-hover-border-color</td>
-                <td><a href="../variables#border-color">text-border-color</a></td>
+                <td><a href="{base}/variables#border-color">text-border-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/button/+page.svelte
+++ b/docs/src/routes/(docs)/components/button/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Knoppen";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Knoppen</title>
 </svelte:head>
@@ -104,17 +108,17 @@
       <section id="button-types">
         <h2>Beschikbare button-types</h2>
         <ul>
-          <li><a href="./button-base">Basis-weergave</a></li>
-          <li><a href="./button-container">Knoppen groeperen</a></li>
-          <li><a href="./button-dropdown">Dropdown button</a></li>
-          <li><a href="./button-ghost">Ghost button</a></li>
-          <li><a href="./button-destructive">Destructieve knop</a></li>
+          <li><a href="{base}/components/button-base">Basis-weergave</a></li>
+          <li><a href="{base}/components/button-container">Knoppen groeperen</a></li>
+          <li><a href="{base}/components/button-dropdown">Dropdown button</a></li>
+          <li><a href="{base}/components/button-ghost">Ghost button</a></li>
+          <li><a href="{base}/components/button-destructive">Destructieve knop</a></li>
           <li>
-            <a href="./button-call-to-action">Call to action button</a>
+            <a href="{base}/components/button-call-to-action">Call to action button</a>
           </li>
-          <li><a href="./button-icon">Icoonknoppen</a></li>
-          <li><a href="./button-icon-only">Icoonknoppen zonder achtergrond</a></li>
-          <li><a href="./button-to-top">Terug naar hoofdmenu</a></li>
+          <li><a href="{base}/components/button-icon">Icoonknoppen</a></li>
+          <li><a href="{base}/components/button-icon-only">Icoonknoppen zonder achtergrond</a></li>
+          <li><a href="{base}/components/button-to-top">Terug naar hoofdmenu</a></li>
         </ul>
       </section>
     </div>

--- a/docs/src/routes/(docs)/components/card/+page.svelte
+++ b/docs/src/routes/(docs)/components/card/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -75,7 +76,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -120,7 +121,7 @@
             <tbody>
               <tr>
                 <td>--card-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-medium)</td>
                 <td rowspan="13" scope="rowgroup">-</td>
                 <td rowspan="25" scope="rowgroup">card</td>
@@ -128,147 +129,147 @@
 
               <tr>
                 <td>--card-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>2rem</td>
               </tr>
 
               <tr>
                 <td>--card-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>1rem</td>
               </tr>
 
               <tr>
                 <td>--card-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>2rem</td>
               </tr>
 
               <tr>
                 <td>--card-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>1rem</td>
               </tr>
 
               <tr>
                 <td>--card-background-color</td>
-                <td><a href="../variables#--card-background-color">--card-background-color</a></td>
+                <td><a href="{base}/variables#--card-background-color">--card-background-color</a></td>
                 <td>var(--application-base-background-color)</td>
               </tr>
 
               <tr>
                 <td>--card-text-color</td>
-                <td><a href="../variables#--card-text-color">--card-text-color</a></td>
+                <td><a href="{base}/variables#--card-text-color">--card-text-color</a></td>
                 <td>var(--application-base-text-color)</td>
               </tr>
 
               <tr>
                 <td>--card-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>var(--application-base-border-radius)</td>
               </tr>
 
               <tr>
                 <td>--card-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
               </tr>
 
               <tr>
                 <td>--card-box-shadow</td>
-                <td><a href="../variables#box-shadow">box-shadow</a></td>
+                <td><a href="{base}/variables#box-shadow">box-shadow</a></td>
                 <td>0</td>
               </tr>
 
               <tr>
                 <td>--card-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
               </tr>
 
               <tr>
                 <td>--card-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
               </tr>
 
               <tr>
                 <td>--card-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--grey-2)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--card-gap)</td>
                 <td rowspan="6" scope="rowgroup">24rem</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--card-padding-top)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--card-padding-right)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--card-padding-bottom)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--card-max-width)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-1-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--card-border-radius)/td&gt; </td></tr
               >
 
               <tr>
                 <td>--card-breakpoint-2-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td> var(--card-breakpoint-1-gap)</td>
                 <td rowspan="6" scope="rowgroup">42rem</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-2-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--card-breakpoint-1-padding-top)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-2-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--card-breakpoint-1-padding-right)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-2-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--card-breakpoint-1-padding-bottom)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-2-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--card-breakpoint-1-padding-left)</td>
               </tr>
 
               <tr>
                 <td>--card-breakpoint-2-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--card-breakpoint-1-max-width)</td>
               </tr>
             </tbody>

--- a/docs/src/routes/(docs)/components/checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/checkbox/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -258,7 +259,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -289,7 +290,7 @@
             <tbody>
               <tr>
                 <td>--checkbox-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.75rem</td>
                 <td>-</td>
                 <td rowspan="7" scope="rowgroup">checkbox</td>
@@ -297,42 +298,42 @@
 
               <tr>
                 <td>--checkbox-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>flex-start</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--checkbox-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--checkbox-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--checkbox-accent-color</td>
-                <td><a href="../variables#accent-color">accent-color</a></td>
+                <td><a href="{base}/variables#accent-color">accent-color</a></td>
                 <td>var(--branding-color-1, initial)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--checkbox-label-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--checkbox-required-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-small)</td>
                 <td>-</td>
               </tr>
@@ -370,7 +371,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./checkbox-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/checkbox-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/collapsible-menu/+page.svelte
+++ b/docs/src/routes/(docs)/components/collapsible-menu/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -75,7 +76,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -116,7 +117,7 @@
             <tbody>
               <tr>
                 <td>--navigation-collapsible-menu-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td rowspan="39" scope="rowgroup">42rem</td>
                 <td>-</td>
@@ -124,266 +125,266 @@
 
               <tr>
                 <td>--navigation-collapsible-menu-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>3rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-max-width</td>
-                <td><a href="../variables#width">max-width</a></td>
+                <td><a href="{base}/variables#width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-z-index</td>
-                <td><a href="../variables#max-z-index">max-z-index</a></td>
+                <td><a href="{base}/variables#max-z-index">max-z-index</a></td>
                 <td>20</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-position</td>
-                <td><a href="../variables#position">position</a></td>
+                <td><a href="{base}/variables#position">position</a></td>
                 <td>absolute</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-top</td>
-                <td><a href="../variables#top">top</a></td>
+                <td><a href="{base}/variables#top">top</a></td>
                 <td>var(--navigation-collapsible-menu-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-right</td>
-                <td><a href="../variables#right">right</a></td>
+                <td><a href="{base}/variables#right">right</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-bottom</td>
-                <td><a href="../variables#bottom">bottom</a></td>
+                <td><a href="{base}/variables#bottom">bottom</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-left</td>
-                <td><a href="../variables#left">left</a></td>
+                <td><a href="{base}/variables#left">left</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>100%</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-collapsed-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-accent-color-tint-2)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-collapsed-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-accent-color-tint-2-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px 0 0 0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--grey-2, #000000)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-background-color, transparent)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-text-color, transparent)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>0 2rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-first-item-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--navigation-collapsible-menu-list-item-collapsed-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-last-item-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px 0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-link-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>none</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-link-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>flex-start</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-hover-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--branding-color-1-background-color, #c0c0c0)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-list-item-collapsed-hover-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--branding-color-1-text-color, #000000)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-button-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-background-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-button-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-button-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>2.75rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-button-min-width</td>
-                <td><a href="../variables#min-width">min-width</a></td>
+                <td><a href="{base}/variables#min-width">min-width</a></td>
                 <td>var(--navigation-collapsible-menu-button-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-button-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>var(--button-base-min-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon</td>
-                <td><a href="../variables#icon">icon</a></td>
+                <td><a href="{base}/variables#icon">icon</a></td>
                 <td>"≡"</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--application-base-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon-color</td>
-                <td><a href="../variables#color">color</a></td>
+                <td><a href="{base}/variables#color">color</a></td>
                 <td>var(--application-base-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon-collapsed</td>
-                <td><a href="../variables#icon">icon</a></td>
+                <td><a href="{base}/variables#icon">icon</a></td>
                 <td>"x"</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon-collapsed-text-color</td>
-                <td><a href="../variables#icon">icon</a></td>
+                <td><a href="{base}/variables#icon">icon</a></td>
                 <td>var(--navigation-collapsible-menu-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--navigation-collapsible-menu-icon-collapsed-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--navigation-collapsible-menu-icon-color)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/de-emphasized/+page.svelte
+++ b/docs/src/routes/(docs)/components/de-emphasized/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -62,7 +63,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -111,7 +112,7 @@
             <tbody>
               <tr>
                 <td>--de-emphasized-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--body-text-small-font-size)</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">de-emphasized</td>
@@ -119,21 +120,21 @@
 
               <tr>
                 <td>--de-emphasized-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--body-text-small-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--de-emphasized-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--body-text-small-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--de-emphasized-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--body-text-small-color)</td>
                 <td>-</td>
               </tr>
@@ -161,7 +162,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./de-emphasized-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/de-emphasized-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/description-list/+page.svelte
+++ b/docs/src/routes/(docs)/components/description-list/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -148,7 +149,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>

--- a/docs/src/routes/(docs)/components/div-content-wrapper-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/div-content-wrapper-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -37,7 +38,7 @@
       <h2>Gebruikte bestanden</h2>
       <p>
         Voor meer informatie over importeren en instellen van componenten. Zie: <a
-          href="../import-styling">Componenten gebruiken en styling toevoegen</a
+          href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
         >
       </p>
 

--- a/docs/src/routes/(docs)/components/div-content-wrapper/+page.svelte
+++ b/docs/src/routes/(docs)/components/div-content-wrapper/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -106,7 +107,7 @@
             <tbody>
               <tr>
                 <td>--div-content-wrapper-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -114,7 +115,7 @@
 
               <tr>
                 <td>--div-content-wrapper-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -122,7 +123,7 @@
 
               <tr>
                 <td>--div-content-wrapper-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -130,7 +131,7 @@
 
               <tr>
                 <td>--div-content-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--content-gap)</td>
                 <td>-</td>
                 <td>-</td>
@@ -138,7 +139,7 @@
 
               <tr>
                 <td>--div-content-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--content-padding-top)</td>
                 <td>-</td>
                 <td>-</td>
@@ -146,7 +147,7 @@
 
               <tr>
                 <td>--div-content-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -154,7 +155,7 @@
 
               <tr>
                 <td>--div-content-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -162,7 +163,7 @@
 
               <tr>
                 <td>--div-content-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -170,7 +171,7 @@
 
               <tr>
                 <td>--div-content-wrapper-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--content-max-width)</td>
                 <td>-</td>
                 <td>-</td>
@@ -210,7 +211,7 @@
               <a href="div-content-wrapper-test">Div content wrapper test</a> Testpagina met de
               content gegroepeerd binnen <code>div</code>'s met een content wrapper.
             </li>
-            <li><a href="./div">Div</a> Content zonder content wrapper.</li>
+            <li><a href="{base}/components/div">Div</a> Content zonder content wrapper.</li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/div-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/div-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -32,7 +33,7 @@
     <h2>Gebruikte bestanden</h2>
     <p>
       Voor meer informatie over importeren en instellen van componenten. Zie: <a
-        href="../import-styling">Componenten gebruiken en styling toevoegen</a
+        href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
       >
     </p>
 

--- a/docs/src/routes/(docs)/components/div/+page.svelte
+++ b/docs/src/routes/(docs)/components/div/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -72,7 +73,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -104,7 +105,7 @@
             <tbody>
               <tr>
                 <td>--div-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -112,7 +113,7 @@
 
               <tr>
                 <td>--div-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -120,7 +121,7 @@
 
               <tr>
                 <td>--div-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -128,7 +129,7 @@
 
               <tr>
                 <td>--div-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -136,7 +137,7 @@
 
               <tr>
                 <td>--div-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -144,7 +145,7 @@
 
               <tr>
                 <td>--div-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -152,7 +153,7 @@
 
               <tr>
                 <td>--div-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -160,7 +161,7 @@
 
               <tr>
                 <td>--div-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -168,7 +169,7 @@
 
               <tr>
                 <td>--div-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -208,7 +209,7 @@
               <a href="div-test">Div test</a> Testpagina met de content gegroepeerd binnen
               <code>div</code>'s.
             </li>
-            <li><a href="./div-content-wrapper">Div content wrapper</a></li>
+            <li><a href="{base}/components/div-content-wrapper">Div content wrapper</a></li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/emphasized/+page.svelte
+++ b/docs/src/routes/(docs)/components/emphasized/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -114,7 +115,7 @@
             <tbody>
               <tr>
                 <td>--emphasized-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--body-text-large-font-size)</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">emphasized</td>
@@ -122,21 +123,21 @@
 
               <tr>
                 <td>--emphasized-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--body-text-large-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--emphasized-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--body-text-large-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--emphasized-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--body-text-large-color)</td>
                 <td>-</td>
               </tr>
@@ -164,7 +165,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./emphasized-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/emphasized-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/fieldset-checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/fieldset-checkbox/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -281,7 +282,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -312,7 +313,7 @@
             <tbody>
               <tr>
                 <td>--fieldset-checkbox-input-margin-top</td>
-                <td><a href="../variables#margin-top">margin-top</a></td>
+                <td><a href="{base}/variables#margin-top">margin-top</a></td>
                 <td>0.25rem</td>
                 <td>-</td>
                 <td rowspan="7" scope="rowgroup">checkbox</td>
@@ -320,35 +321,35 @@
 
               <tr>
                 <td>--fieldset-checkbox-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-checkbox-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-checkbox-accent-color</td>
-                <td><a href="../variables#accent-color">accent-color</a></td>
+                <td><a href="{base}/variables#accent-color">accent-color</a></td>
                 <td>var(--branding-color-1, initial)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-checkbox-label-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-checkbox-required-margin-bottom</td>
-                <td><a href="../variables#margin-bottom">margin-bottom</a></td>
+                <td><a href="{base}/variables#margin-bottom">margin-bottom</a></td>
                 <td>var(--application-base-gap-small)</td>
                 <td>-</td>
               </tr>
@@ -385,7 +386,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./fieldset-checkbox-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/fieldset-checkbox-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/fieldset-radio/+page.svelte
+++ b/docs/src/routes/(docs)/components/fieldset-radio/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -254,7 +255,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -285,7 +286,7 @@
             <tbody>
               <tr>
                 <td>--fieldset-radio-input-margin-top</td>
-                <td><a href="../variables#margin-top">margin-top</a></td>
+                <td><a href="{base}/variables#margin-top">margin-top</a></td>
                 <td>0.25rem</td>
                 <td>-</td>
                 <td rowspan="7" scope="rowgroup">radio</td>
@@ -293,35 +294,35 @@
 
               <tr>
                 <td>--fieldset-radio-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-radio-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-radio-accent-color</td>
-                <td><a href="../variables#accent-color">accent-color</a></td>
+                <td><a href="{base}/variables#accent-color">accent-color</a></td>
                 <td>var(--branding-color-1, initial)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-radio-label-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--fieldset-radio-required-margin-bottom</td>
-                <td><a href="../variables#margin-bottom">margin-bottom</a></td>
+                <td><a href="{base}/variables#margin-bottom">margin-bottom</a></td>
                 <td>var(--application-base-gap-small)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/filter/+page.svelte
+++ b/docs/src/routes/(docs)/components/filter/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -48,7 +49,7 @@
               <li>
                 Voeg het bijbehorende Javascript-bestand toe aan het project. Voor meer informatie
                 zie:
-                <a href="../add-js">JavaScript toevoegen</a>.
+                <a href="{base}/add-js">JavaScript toevoegen</a>.
               </li>
             </ul>
           </li>
@@ -59,7 +60,7 @@
           <li>
             Voeg binnen het element een formulier met de beschikbare filteropties toe. Voor meer
             informatie over zie:
-            <a href="./forms">Formulieren</a>.
+            <a href="{base}/components/forms">Formulieren</a>.
           </li>
           <li>
             Geef het formulier met <code>aria-label</code> een korte toegankelijke naam.
@@ -283,7 +284,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -303,32 +304,32 @@
           <li>
             Intro
             <ul>
-              <li><a href="../variables#padding">padding</a></li>
+              <li><a href="{base}/variables#padding">padding</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
-              <li><a href="../variables#font-size">font-size</a></li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
           <li>
             <code>span</code>
             <ul>
-              <li><a href="../variables#font-size">font-size</a></li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
           <li>
             <code>button</code>
             <ul>
-              <li><a href="../variables#text-color">text-color</a></li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
         </ul>
@@ -336,7 +337,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./filter-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/filter-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/finn-large/+page.svelte
+++ b/docs/src/routes/(docs)/components/finn-large/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -105,7 +106,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -120,7 +121,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -146,7 +147,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -182,37 +183,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -224,37 +225,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -266,37 +267,37 @@
 
               <tr>
                 <td>--branding-color-3-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -308,37 +309,37 @@
 
               <tr>
                 <td>--branding-color-4-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-4-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -350,37 +351,37 @@
 
               <tr>
                 <td>--branding-color-5-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-5-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/finn-medium/+page.svelte
+++ b/docs/src/routes/(docs)/components/finn-medium/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -95,7 +96,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -110,7 +111,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -136,7 +137,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -172,37 +173,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -214,37 +215,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -256,37 +257,37 @@
 
               <tr>
                 <td>--branding-color-3-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-3-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/finn-small/+page.svelte
+++ b/docs/src/routes/(docs)/components/finn-small/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -90,7 +91,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -105,7 +106,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -131,7 +132,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten, zie
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -167,37 +168,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -209,37 +210,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/focus-only/+page.svelte
+++ b/docs/src/routes/(docs)/components/focus-only/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -59,7 +60,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -75,7 +76,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./focus-only-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/focus-only-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/font/+page.svelte
+++ b/docs/src/routes/(docs)/components/font/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -217,7 +218,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>

--- a/docs/src/routes/(docs)/components/footer-two-thirds-one-third/+page.svelte
+++ b/docs/src/routes/(docs)/components/footer-two-thirds-one-third/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -53,9 +54,9 @@
   <nav aria-labelledby="footer-nav-1-heading">
     <h1 id="footer-nav-1-heading">Lorem ipsum</h1>
     <ul>
-      <li><a href="./footer-base">Dolor</a></li>
-      <li><a href="./footer-base">Sit</a></li>
-      <li><a href="./footer-base">Amet</a></li>
+      <li><a href="{base}/components/footer-base">Dolor</a></li>
+      <li><a href="{base}/components/footer-base">Sit</a></li>
+      <li><a href="{base}/components/footer-base">Amet</a></li>
     </ul>
   </nav>
 </footer>
@@ -78,7 +79,7 @@
         <p>Voeg de (s)css-bestanden toe aan het project of importeer de bestanden.</p>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Importeer component via NPM</h3>
         <h4>CSS-voorbeeld:</h4>
@@ -107,7 +108,7 @@
             <tbody>
               <tr>
                 <td>--footer-two-thirds-one-third-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>column</td>
                 <td>-</td>
                 <td>-</td>
@@ -115,7 +116,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -123,7 +124,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>flex-end</td>
                 <td>-</td>
                 <td>-</td>
@@ -131,7 +132,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>center</td>
                 <td>-</td>
                 <td>-</td>
@@ -139,7 +140,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-flex-wrap</td>
-                <td><a href="../variables#flex-wrap">flex-wrap</a></td>
+                <td><a href="{base}/variables#flex-wrap">flex-wrap</a></td>
                 <td>wrap</td>
                 <td>-</td>
                 <td>-</td>
@@ -147,7 +148,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>10rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -155,7 +156,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-tint-1-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -163,7 +164,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-tint-1-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -171,7 +172,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -179,7 +180,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -187,7 +188,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -195,7 +196,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -203,7 +204,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -211,7 +212,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-link-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--footer-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -219,7 +220,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-link-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>none</td>
                 <td>-</td>
                 <td>-</td>
@@ -227,7 +228,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-link-hover-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--footer-link-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -235,7 +236,7 @@
 
               <tr>
                 <td>--footer-two-thirds-one-third-link-hover-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>underline</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/footer/+page.svelte
+++ b/docs/src/routes/(docs)/components/footer/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -62,9 +63,9 @@
   <nav aria-labelledby="footer-nav-1-heading">
     <h1 id="footer-nav-1-heading">Lorem ipsum</h1>
     <ul>
-      <li><a href="./footer-base">Dolor</a></li>
-      <li><a href="./footer-base">Sit</a></li>
-      <li><a href="./footer-base">Amet</a></li>
+      <li><a href="{base}/components/footer-base">Dolor</a></li>
+      <li><a href="{base}/components/footer-base">Sit</a></li>
+      <li><a href="{base}/components/footer-base">Amet</a></li>
     </ul>
   </nav>
 </footer>
@@ -87,7 +88,7 @@
         <p>Voeg de (s)css-bestanden toe aan het project of importeer de bestanden.</p>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h2>Importeer component via NPM</h2>
         <h3>CSS-voorbeeld:</h3>
@@ -116,7 +117,7 @@
             <tbody>
               <tr>
                 <td>--footer-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>column</td>
                 <td>-</td>
                 <td>-</td>
@@ -124,7 +125,7 @@
 
               <tr>
                 <td>--footer-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-medium)</td>
                 <td>-</td>
                 <td>-</td>
@@ -132,7 +133,7 @@
 
               <tr>
                 <td>--footer-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>center</td>
                 <td>-</td>
                 <td>-</td>
@@ -140,7 +141,7 @@
 
               <tr>
                 <td>--footer-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>flex-start</td>
                 <td>-</td>
                 <td>-</td>
@@ -148,7 +149,7 @@
 
               <tr>
                 <td>--footer-flex-wrap</td>
-                <td><a href="../variables#flex-wrap">flex-wrap</a></td>
+                <td><a href="{base}/variables#flex-wrap">flex-wrap</a></td>
                 <td>wrap</td>
                 <td>-</td>
                 <td>-</td>
@@ -156,7 +157,7 @@
 
               <tr>
                 <td>--footer-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>10rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -164,7 +165,7 @@
 
               <tr>
                 <td>--footer-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-tint-1-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -172,7 +173,7 @@
 
               <tr>
                 <td>--footer-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-tint-1-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -180,7 +181,7 @@
 
               <tr>
                 <td>--footer-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--content-padding-top)</td>
                 <td>-</td>
                 <td>-</td>
@@ -188,7 +189,7 @@
 
               <tr>
                 <td>--footer-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>5%</td>
                 <td>-</td>
                 <td>-</td>
@@ -196,7 +197,7 @@
 
               <tr>
                 <td>--footer-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -204,7 +205,7 @@
 
               <tr>
                 <td>--footer-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>5%</td>
                 <td>-</td>
                 <td>-</td>
@@ -212,7 +213,7 @@
 
               <tr>
                 <td>--footer-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -220,7 +221,7 @@
 
               <tr>
                 <td>--footer-link-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--footer-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -228,7 +229,7 @@
 
               <tr>
                 <td>--footer-link-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>none</td>
                 <td>-</td>
                 <td>-</td>
@@ -236,7 +237,7 @@
 
               <tr>
                 <td>--footer-link-hover-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--footer-link-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -244,7 +245,7 @@
 
               <tr>
                 <td>--footer-link-hover-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>underline</td>
                 <td>-</td>
                 <td>-</td>
@@ -284,7 +285,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./footer-two-thirds-one-third">Footer tweederde eenderde</a>
+        <a href="{base}/components/footer-two-thirds-one-third">Footer tweederde eenderde</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-accent-color/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-accent-color/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -155,7 +156,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h4>Benodigd</h4>
         <ul>
@@ -171,18 +172,18 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#accent-color">accent-color</a></li>
+          <li><a href="{base}/variables#accent-color">accent-color</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-accent-color-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-accent-color-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-base/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -40,7 +41,7 @@
           </li>
           <li>
             Groepeer de formulierelementen voor toegankelijkheid en gebruikersgemak. Zie
-            <a href="./form-fieldset">Invoervelden groeperen</a> voor meer informatie.
+            <a href="{base}/components/form-fieldset">Invoervelden groeperen</a> voor meer informatie.
           </li>
           <li>
             Voeg indien nodig of ten behoeve van gebruikersgemak meldingen, toelichtingen en
@@ -86,7 +87,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -103,42 +104,42 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#align-items">align-items</a></li>
+          <li><a href="{base}/variables#align-items">align-items</a></li>
           <li>
-            <a href="../variables#justify-content">justify-content</a>
+            <a href="{base}/variables#justify-content">justify-content</a>
           </li>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#text-color">text-color</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#line-height">line-height</a></li>
-          <li><a href="../variables#font-weight">font-weight</a></li>
-          <li><a href="../variables#gap">gap</a></li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
-          <li><a href="../variables#breakpoint">breakpoint</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#line-height">line-height</a></li>
+          <li><a href="{base}/variables#font-weight">font-weight</a></li>
+          <li><a href="{base}/variables#gap">gap</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#breakpoint">breakpoint</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-base-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-base-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-columns/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-columns/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -80,7 +81,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -100,13 +101,13 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
           <li>
             Gewenste layout, bijvoorbeeld:
             <ul>
-              <li><a href="./layout-column-2">layout-column-2</a></li>
-              <li><a href="./layout-column-3">layout-column-3</a></li>
-              <li><a href="./layout-column-4">layout-column-4</a></li>
+              <li><a href="{base}/components/layout-column-2">layout-column-2</a></li>
+              <li><a href="{base}/components/layout-column-3">layout-column-3</a></li>
+              <li><a href="{base}/components/layout-column-4">layout-column-4</a></li>
             </ul>
             Voor alle beschikbare opties zie
             <a href="layouts#layout-types">layout weergave opties</a>.
@@ -116,7 +117,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-columns-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-columns-test">Test- en voorbeelden-pagina</a>
       </section>
 
       <section id="issues">

--- a/docs/src/routes/(docs)/components/form-combined-fields/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-combined-fields/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -42,7 +43,7 @@
         <ol>
           <li>
             Gecombineerde velden worden vaak gebruikt met icoonknoppen. Voor meer informatie zie:
-            <a href="./button-icon">Icoonknoppen</a>.
+            <a href="{base}/components/button-icon">Icoonknoppen</a>.
           </li>
         </ol>
       </section>
@@ -91,7 +92,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -112,13 +113,13 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-combined-fields-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-combined-fields-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-fieldset-invisible/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-fieldset-invisible/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -92,7 +93,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -110,24 +111,24 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#width">width</a></li>
-          <li><a href="../variables#resize">resize</a></li>
-          <li><a href="../variables#min-height">min-height</a></li>
-          <li><a href="../variables#padding">padding</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#font-family">font-family</a></li>
-          <li><a href="../variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#width">width</a></li>
+          <li><a href="{base}/variables#resize">resize</a></li>
+          <li><a href="{base}/variables#min-height">min-height</a></li>
+          <li><a href="{base}/variables#padding">padding</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#font-family">font-family</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
     </div>

--- a/docs/src/routes/(docs)/components/form-fieldset/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-fieldset/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -85,7 +86,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -116,7 +117,7 @@
             <tbody>
               <tr>
                 <td>--form-fieldset-fields-margin-top</td>
-                <td><a href="../variables#margin-top">margin-top</a></td>
+                <td><a href="{base}/variables#margin-top">margin-top</a></td>
                 <td>var(--application-base-gap, 1rem)</td>
                 <td>-</td>
                 <td>-</td>
@@ -124,7 +125,7 @@
 
               <tr>
                 <td>--form-fieldset-legend-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-font-weight, bold)</td>
                 <td>-</td>
                 <td>-</td>
@@ -132,7 +133,7 @@
 
               <tr>
                 <td>--form-fieldset-legend-margin-bottom</td>
-                <td><a href="../variables#margin-bottom">margin-bottom</a></td>
+                <td><a href="{base}/variables#margin-bottom">margin-bottom</a></td>
                 <td>var(--application-base-gap, 1rem)</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/form-help/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-help/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -38,7 +39,7 @@
               <li>
                 Voeg het bijbehorende Javascript-bestand toe aan het project. Voor meer informatie
                 zie:
-                <a href="../add-js">JavaScript toevoegen</a>.
+                <a href="{base}/add-js">JavaScript toevoegen</a>.
               </li>
             </ul>
           </li>
@@ -214,7 +215,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -233,50 +234,50 @@
           <li>
             <code>button</code>
             <ul>
-              <li><a href="../variables#width">width</a></li>
-              <li><a href="../variables#height">height</a></li>
+              <li><a href="{base}/variables#width">width</a></li>
+              <li><a href="{base}/variables#height">height</a></li>
               <li>
-                <a href="../variables#padding-top">padding-top</a>
+                <a href="{base}/variables#padding-top">padding-top</a>
               </li>
               <li>
-                <a href="../variables#padding-right">padding-right</a>
+                <a href="{base}/variables#padding-right">padding-right</a>
               </li>
               <li>
-                <a href="../variables#padding-bottom">padding-bottom</a>
+                <a href="{base}/variables#padding-bottom">padding-bottom</a>
               </li>
               <li>
-                <a href="../variables#padding-left">padding-left</a>
+                <a href="{base}/variables#padding-left">padding-left</a>
               </li>
-              <li><a href="../variables#top">top</a></li>
-              <li><a href="../variables#right">right</a></li>
+              <li><a href="{base}/variables#top">top</a></li>
+              <li><a href="{base}/variables#right">right</a></li>
               <li>
-                <a href="../variables#border-width">border-width</a>
-              </li>
-              <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-radius">border-radius</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#border-radius">border-radius</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li>
+                <a href="{base}/variables#background-color">background-color</a>
+              </li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
           <li>
             Icoon
             <ul>
-              <li><a href="../variables#content">content</a></li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#content">content</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
               <li>
-                <a href="../variables#font-weight">font-weight</a>
+                <a href="{base}/variables#font-weight">font-weight</a>
               </li>
               <li>
-                <a href="../variables#line-height">line-height</a>
+                <a href="{base}/variables#line-height">line-height</a>
               </li>
             </ul>
           </li>
@@ -284,14 +285,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
           <li>Formulierelementen</li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-help-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-help-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-horizontal-view/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-horizontal-view/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -139,7 +140,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -160,32 +161,32 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#justify-content">justify-content</a>
+            <a href="{base}/variables#justify-content">justify-content</a>
           </li>
-          <li><a href="../variables#gap">gap</a></li>
+          <li><a href="{base}/variables#gap">gap</a></li>
           <li>
             Label
             <ul>
-              <li><a href="../variables#max-width">max-width</a></li>
+              <li><a href="{base}/variables#max-width">max-width</a></li>
             </ul>
           </li>
           <li>
             Invoervelden
             <ul>
-              <li><a href="../variables#max-width">max-width</a></li>
+              <li><a href="{base}/variables#max-width">max-width</a></li>
             </ul>
           </li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-horizontal-view-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-horizontal-view-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-inline/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-inline/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -66,7 +67,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -85,18 +86,18 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-inline-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-inline-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-color-filled/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-color-filled/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -82,7 +83,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -105,14 +106,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./form-input">form-input</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/form-input">form-input</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-color-filled-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-color-filled-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-color/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-color/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -73,7 +74,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -94,14 +95,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./form-input">form-input</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/form-input">form-input</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-color-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-color-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-date/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-date/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -86,14 +87,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./form-input">form-input</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/form-input">form-input</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-date-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-date-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-email/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-email/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -86,14 +87,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./form-input">form-input</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/form-input">form-input</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-email-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-email-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-file/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-file/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -40,7 +41,7 @@
         <p class="explanation">
           <strong>Tip:</strong> Om bereik-invoervelden een eigen gekozen kleur mee te geven kan
           gebruik gemaakt worden van
-          <a href="./form-accent-color">accentkleur op formulierelementen</a>.
+          <a href="{base}/components/form-accent-color">accentkleur op formulierelementen</a>.
         </p>
       </section>
 
@@ -76,7 +77,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Optioneel</h3>
@@ -92,13 +93,13 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-file-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-file-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-password/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-password/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -147,7 +148,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -168,14 +169,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./form-input">form-input</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/form-input">form-input</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-password-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-password-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-radio/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-radio/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -130,7 +131,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -175,7 +176,7 @@
             <tbody>
               <tr>
                 <td>--radio-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.75rem</td>
                 <td>-</td>
                 <td rowspan="7" scope="rowgroup">radio-button</td>
@@ -183,42 +184,42 @@
 
               <tr>
                 <td>--radio-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>center</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--radio-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--radio-height</td>
-                <td><a href="../variables#height">height</a></td>
+                <td><a href="{base}/variables#height">height</a></td>
                 <td>1.25rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--radio-accent-color</td>
-                <td><a href="../variables#accent-color">accent-color</a></td>
+                <td><a href="{base}/variables#accent-color">accent-color</a></td>
                 <td>var(--branding-color-1, initial)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--radio-label-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>auto</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--radio-required-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-small)</td>
                 <td>-</td>
               </tr>
@@ -255,7 +256,7 @@
       </section>
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-radio-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-radio-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-range/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-range/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -40,7 +41,7 @@
         <p class="explanation">
           <strong>Tip:</strong> Om bereik-invoervelden een eigen gekozen kleur mee te geven kan
           gebruik gemaakt worden van
-          <a href="./form-accent-color">accentkleur op formulierelementen</a>.
+          <a href="{base}/components/form-accent-color">accentkleur op formulierelementen</a>.
         </p>
       </section>
 
@@ -96,7 +97,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Optioneel</h3>
@@ -112,13 +113,13 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-range-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-range-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input-textarea/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-textarea/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -88,7 +89,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -106,30 +107,30 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#width">width</a></li>
-          <li><a href="../variables#resize">resize</a></li>
-          <li><a href="../variables#min-height">min-height</a></li>
-          <li><a href="../variables#padding">padding</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#font-family">font-family</a></li>
-          <li><a href="../variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#width">width</a></li>
+          <li><a href="{base}/variables#resize">resize</a></li>
+          <li><a href="{base}/variables#min-height">min-height</a></li>
+          <li><a href="{base}/variables#padding">padding</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#font-family">font-family</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-textarea-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-textarea-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-input/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -160,7 +161,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h2>Benodigd</h2>
         <ul>
@@ -178,31 +179,31 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#text-color">text-color</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#line-height">line-height</a></li>
-          <li><a href="../variables#font-weight">font-weight</a></li>
-          <li><a href="../variables#min-height">min-height</a></li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#line-height">line-height</a></li>
+          <li><a href="{base}/variables#font-weight">font-weight</a></li>
+          <li><a href="{base}/variables#min-height">min-height</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-input-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-input-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-notification/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-notification/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -263,7 +264,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Gerelateerd:</h3>
@@ -299,7 +300,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-notification-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-notification-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-required/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-required/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -45,7 +46,7 @@
             Indien het formulier horizontaal uitgelijnd is: groeppeer de
             <code>&lt;input&gt;</code> en de <code>&lt;span&gt;</code> samen in een
             <code>&lt;div&gt;</code>. Voor meer informatie zie
-            <a href="./form-horizontal-view">Horizontaal uitgelijnd formulier</a>.
+            <a href="{base}/components/form-horizontal-view">Horizontaal uitgelijnd formulier</a>.
           </li>
         </ol>
       </section>
@@ -95,7 +96,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -117,14 +118,14 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
-          <li><a href="./nota-bene">nota-bene</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
+          <li><a href="{base}/components/nota-bene">nota-bene</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-required-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-required-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/form-select/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-select/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -164,7 +165,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -185,13 +186,13 @@
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./form-select-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/form-select-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/forms/+page.svelte
+++ b/docs/src/routes/(docs)/components/forms/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Formulieren";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Formulieren</title>
 </svelte:head>
@@ -23,36 +27,36 @@
             <h3 id="form-types-title">Formulierelementen</h3>
             <ul>
               <li>
-                <a href="./form-input-range">Bereik - <code>range</code></a>
+                <a href="{base}/components/form-input-range">Bereik - <code>range</code></a>
               </li>
               <li>
-                <a href="./form-input-file">Bestand - <code>file</code></a>
+                <a href="{base}/components/form-input-file">Bestand - <code>file</code></a>
               </li>
-              <li><a href="./form-input-date">Datum</a></li>
-              <li><a href="./form-input-email">Email</a></li>
+              <li><a href="{base}/components/form-input-date">Datum</a></li>
+              <li><a href="{base}/components/form-input-email">Email</a></li>
               <li>
-                <a href="./form-input">Invoerveld - <code>input</code></a>
+                <a href="{base}/components/form-input">Invoerveld - <code>input</code></a>
               </li>
               <li>
                 Kleurselector
                 <ul>
                   <li>
-                    <a href="./form-input-color">Kleurselector</a>
+                    <a href="{base}/components/form-input-color">Kleurselector</a>
                   </li>
                   <li>
-                    <a href="./form-input-color-filled">Kleurselector volledig gevuld</a>
+                    <a href="{base}/components/form-input-color-filled">Kleurselector volledig gevuld</a>
                   </li>
                 </ul>
               </li>
-              <li><a href="./form-notification">Notificatie</a></li>
-              <li><a href="./form-input-radio">Radio-selecteerknop - <code>radio</code></a></li>
-              <li><a href="./form-input-password">Wachtwoord</a></li>
-              <li><a href="./checkbox">Selectievak - <code>checkbox</code></a></li>
+              <li><a href="{base}/components/form-notification">Notificatie</a></li>
+              <li><a href="{base}/components/form-input-radio">Radio-selecteerknop - <code>radio</code></a></li>
+              <li><a href="{base}/components/form-input-password">Wachtwoord</a></li>
+              <li><a href="{base}/components/checkbox">Selectievak - <code>checkbox</code></a></li>
               <li>
-                <a href="./form-input-textarea">Tekstveld - <code>textarea</code></a>
+                <a href="{base}/components/form-input-textarea">Tekstveld - <code>textarea</code></a>
               </li>
               <li>
-                <a href="./form-select">Selectielijst - <code>select</code></a>
+                <a href="{base}/components/form-select">Selectielijst - <code>select</code></a>
               </li>
             </ul>
           </nav>
@@ -61,13 +65,13 @@
             <h3 id="form-fieldset-components-title">Fieldset</h3>
 
             <ul>
-              <li><a href="./form-fieldset">Fieldset</a></li>
-              <li><a href="./form-fieldset-invisible">Onzichtbare fieldset</a></li>
+              <li><a href="{base}/components/form-fieldset">Fieldset</a></li>
+              <li><a href="{base}/components/form-fieldset-invisible">Onzichtbare fieldset</a></li>
               <li>
-                <a href="./fieldset-radio">Fieldset radio-selecteerknop - <code>radio</code></a>
+                <a href="{base}/components/fieldset-radio">Fieldset radio-selecteerknop - <code>radio</code></a>
               </li>
               <li>
-                <a href="./fieldset-checkbox">Fieldset selectievak - <code>checkbox</code></a>
+                <a href="{base}/components/fieldset-checkbox">Fieldset selectievak - <code>checkbox</code></a>
               </li>
             </ul>
           </nav>
@@ -75,28 +79,28 @@
           <nav aria-labelledby="form-layouts-title" id="form-layouts">
             <h3 id="form-layouts-title">Weergaven</h3>
             <ul>
-              <li><a href="./form-base">Basisweergave</a></li>
+              <li><a href="{base}/components/form-base">Basisweergave</a></li>
               <li>
-                <a href="./form-accent-color">Accentkleur op formulierelementen</a>
+                <a href="{base}/components/form-accent-color">Accentkleur op formulierelementen</a>
               </li>
               <li>
-                <a href="./form-combined-fields">Gecombineerde formuliervelden</a>
+                <a href="{base}/components/form-combined-fields">Gecombineerde formuliervelden</a>
               </li>
               <li>
-                <a href="./form-columns">Weergave in kolommen</a>
+                <a href="{base}/components/form-columns">Weergave in kolommen</a>
               </li>
               <li>
-                <a href="./form-horizontal-view">Horizontaal uitgelijnd formulier</a>
+                <a href="{base}/components/form-horizontal-view">Horizontaal uitgelijnd formulier</a>
               </li>
-              <li><a href="./form-inline">"inline"-formulier</a></li>
+              <li><a href="{base}/components/form-inline">"inline"-formulier</a></li>
             </ul>
           </nav>
 
           <nav id="form-communication">
             <h3>Berichten en meldingen</h3>
             <ul>
-              <li><a href="./form-required">Verplichte velden</a></li>
-              <li><a href="./form-help">Hulpteksten</a></li>
+              <li><a href="{base}/components/form-required">Verplichte velden</a></li>
+              <li><a href="{base}/components/form-help">Hulpteksten</a></li>
             </ul>
           </nav>
         </div>

--- a/docs/src/routes/(docs)/components/header-navigation/+page.svelte
+++ b/docs/src/routes/(docs)/components/header-navigation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -46,20 +47,20 @@
       <section id="examples">
         <h1>Voorbeelden:</h1>
         <ul>
-          <li><a href="./header-navigation/example">Navigatie</a></li>
+          <li><a href="{base}/components/header-navigation/example">Navigatie</a></li>
           <li>
-            <a href="./header-navigation/example-content-wrapper">Navigatie met content wrapper</a>
+            <a href="{base}/components/header-navigation/example-content-wrapper">Navigatie met content wrapper</a>
           </li>
-          <li><a href="./header-navigation/example-logo">Navigatie en logo</a></li>
-          <li><a href="./header-navigation/example-logo-above">Navigatie met Logo bovenaan</a></li>
+          <li><a href="{base}/components/header-navigation/example-logo">Navigatie en logo</a></li>
+          <li><a href="{base}/components/header-navigation/example-logo-above">Navigatie met Logo bovenaan</a></li>
           <li>
-            <a href="./header-navigation/example-multiple-menus">Navigatie met meerdere menu's</a>
-          </li>
-          <li>
-            <a href="./header-navigation/example-language-select-list">Navigatie taalselectie</a>
+            <a href="{base}/components/header-navigation/example-multiple-menus">Navigatie met meerdere menu's</a>
           </li>
           <li>
-            <a href="./header-navigation/example-form-button">Navigatie met formulier knop</a>
+            <a href="{base}/components/header-navigation/example-language-select-list">Navigatie taalselectie</a>
+          </li>
+          <li>
+            <a href="{base}/components/header-navigation/example-form-button">Navigatie met formulier knop</a>
           </li>
         </ul>
       </section>
@@ -69,7 +70,7 @@
         <p>Voeg de (s)css-bestanden toe aan het project of importeer de bestanden.</p>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h2>Importeer component via NPM</h2>
         <h3>CSS-voorbeeld:</h3>
@@ -98,7 +99,7 @@
             <tbody>
               <tr>
                 <td>--header-navigation-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>column</td>
                 <td>-</td>
                 <td>-</td>
@@ -106,7 +107,7 @@
 
               <tr>
                 <td>--header-navigation-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--application-base-gap-medium)</td>
                 <td>-</td>
                 <td>-</td>
@@ -114,7 +115,7 @@
 
               <tr>
                 <td>--header-navigation-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>center</td>
                 <td>-</td>
                 <td>-</td>
@@ -122,7 +123,7 @@
 
               <tr>
                 <td>--header-navigation-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>flex-start</td>
                 <td>-</td>
                 <td>-</td>
@@ -130,7 +131,7 @@
 
               <tr>
                 <td>--header-navigation-flex-wrap</td>
-                <td><a href="../variables#flex-wrap">flex-wrap</a></td>
+                <td><a href="{base}/variables#flex-wrap">flex-wrap</a></td>
                 <td>wrap</td>
                 <td>-</td>
                 <td>-</td>
@@ -138,7 +139,7 @@
 
               <tr>
                 <td>--header-navigation-min-height</td>
-                <td><a href="../variables#min-height">min-height</a></td>
+                <td><a href="{base}/variables#min-height">min-height</a></td>
                 <td>10rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -146,7 +147,7 @@
 
               <tr>
                 <td>--header-navigation-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-tint-1-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -154,7 +155,7 @@
 
               <tr>
                 <td>--header-navigation-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-tint-1-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -162,7 +163,7 @@
 
               <tr>
                 <td>--header-navigation-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--content-padding-top)</td>
                 <td>-</td>
                 <td>-</td>
@@ -170,7 +171,7 @@
 
               <tr>
                 <td>--header-navigation-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>5%</td>
                 <td>-</td>
                 <td>-</td>
@@ -178,7 +179,7 @@
 
               <tr>
                 <td>--header-navigation-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -186,7 +187,7 @@
 
               <tr>
                 <td>--header-navigation-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>5%</td>
                 <td>-</td>
                 <td>-</td>
@@ -194,7 +195,7 @@
 
               <tr>
                 <td>--header-navigation-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -202,7 +203,7 @@
 
               <tr>
                 <td>--header-navigation-link-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--header-navigation-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -210,7 +211,7 @@
 
               <tr>
                 <td>--header-navigation-link-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>none</td>
                 <td>-</td>
                 <td>-</td>
@@ -218,7 +219,7 @@
 
               <tr>
                 <td>--header-navigation-link-hover-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--header-navigation-link-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -226,7 +227,7 @@
 
               <tr>
                 <td>--header-navigation-link-hover-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>underline</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/heading-base-set/+page.svelte
+++ b/docs/src/routes/(docs)/components/heading-base-set/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -45,7 +46,7 @@
                 classes binnen de HTML. Maak gebruik van de CSS-variabelen waar mogelijk en voeg
                 alleen de classes toe in de HTML voor uitzonderingen om de code aanpasbaar en
                 overzichtelijk te houden. Voor meer informatie hierover zie <a
-                  href="../use-css-variable">CSS-variabelen gebruiken</a
+                  href="{base}/use-css-variable">CSS-variabelen gebruiken</a
                 >.
               </li>
             </ul>
@@ -106,7 +107,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -151,7 +152,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -184,7 +185,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-base-set</th>
                 <td>--headings-base-set-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--application-base-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">-</td>
@@ -192,35 +193,35 @@
 
               <tr>
                 <td>--headings-base-set-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>1.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--headings-base-set-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>bold</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--headings-base-set-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--application-base-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--headings-base-set-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--application-base-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--headings-base-set-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
@@ -228,7 +229,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-xxl</th>
                 <td>--heading-xxl-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-xxl</td>
@@ -236,35 +237,35 @@
 
               <tr>
                 <td>--heading-xxl-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>2.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xxl-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xxl-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xxl-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xxl-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>
@@ -272,7 +273,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-xl</th>
                 <td>--heading-xl-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-xl</td>
@@ -280,35 +281,35 @@
 
               <tr>
                 <td>--heading-xl-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>2rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xl-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xl-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xl-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xl-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>
@@ -316,7 +317,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-large</th>
                 <td>--heading-large-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-large</td>
@@ -324,35 +325,35 @@
 
               <tr>
                 <td>--heading-large-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>1.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-large-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-large-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-large-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-large-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>
@@ -360,7 +361,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-normal</th>
                 <td>--heading-normal-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-normal</td>
@@ -368,35 +369,35 @@
 
               <tr>
                 <td>--heading-normal-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>1rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-normal-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-normal-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-normal-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-normal-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>
@@ -404,7 +405,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-small</th>
                 <td>--heading-small-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-small</td>
@@ -412,35 +413,35 @@
 
               <tr>
                 <td>--heading-small-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0.8rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-small-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-small-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-small-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-small-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>
@@ -448,7 +449,7 @@
               <tr>
                 <th rowspan="6" scope="rowgroup">heading-xs</th>
                 <td>--heading-xs-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--headings-base-set-font-family)</td>
                 <td>-</td>
                 <td rowspan="6" scope="rowgroup">heading-xs</td>
@@ -456,35 +457,35 @@
 
               <tr>
                 <td>--heading-xs-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>0.7rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xs-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--headings-base-set-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xs-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--headings-base-set-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xs-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--headings-base-set-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--heading-xs-margin</td>
-                <td><a href="../variables#margin">margin</a></td>
+                <td><a href="{base}/variables#margin">margin</a></td>
                 <td>var(--headings-base-set-margin)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/headings/+page.svelte
+++ b/docs/src/routes/(docs)/components/headings/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -166,7 +167,7 @@
           <h2>Bijbehorende bestanden</h2>
           <p>
             Voor meer informatie over importeren en instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </p>
 
           <h3>Importeer component via NPM</h3>
@@ -217,7 +218,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">headings</th>
                   <td>--headings-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--application-base-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -225,7 +226,7 @@
 
                 <tr>
                   <td>--headings-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>1.5rem</td>
                   <td>-</td>
                   <td>-</td>
@@ -233,7 +234,7 @@
 
                 <tr>
                   <td>--headings-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>bold</td>
                   <td>-</td>
                   <td>-</td>
@@ -241,7 +242,7 @@
 
                 <tr>
                   <td>--headings-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--application-base-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -249,7 +250,7 @@
 
                 <tr>
                   <td>--headings-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--application-base-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -257,7 +258,7 @@
 
                 <tr>
                   <td>--headings-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>1rem</td>
                   <td>-</td>
                   <td>-</td>
@@ -266,7 +267,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h1</th>
                   <td>--h1-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -274,7 +275,7 @@
 
                 <tr>
                   <td>--h1-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-xxl-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -282,7 +283,7 @@
 
                 <tr>
                   <td>--h1-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-xxl-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -290,7 +291,7 @@
 
                 <tr>
                   <td>--h1-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-xxl-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -298,7 +299,7 @@
 
                 <tr>
                   <td>--h1-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-xxl-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -306,7 +307,7 @@
 
                 <tr>
                   <td>--h1-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-xxl-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -315,7 +316,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h2</th>
                   <td>--h2-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -323,7 +324,7 @@
 
                 <tr>
                   <td>--h2-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-xl-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -331,7 +332,7 @@
 
                 <tr>
                   <td>--h2-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-xl-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -339,7 +340,7 @@
 
                 <tr>
                   <td>--h2-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-xl-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -347,7 +348,7 @@
 
                 <tr>
                   <td>--h2-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-xl-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -355,7 +356,7 @@
 
                 <tr>
                   <td>--h2-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-xl-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -364,7 +365,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h3</th>
                   <td>--h3-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -372,7 +373,7 @@
 
                 <tr>
                   <td>--h3-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-large-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -380,7 +381,7 @@
 
                 <tr>
                   <td>--h3-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-large-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -388,7 +389,7 @@
 
                 <tr>
                   <td>--h3-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-large-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -396,7 +397,7 @@
 
                 <tr>
                   <td>--h3-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-large-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -404,7 +405,7 @@
 
                 <tr>
                   <td>--h3-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-large-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -413,7 +414,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h4</th>
                   <td>--h4-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -421,7 +422,7 @@
 
                 <tr>
                   <td>--h4-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-normal-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -429,7 +430,7 @@
 
                 <tr>
                   <td>--h4-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-normal-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -437,7 +438,7 @@
 
                 <tr>
                   <td>--h4-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-normal-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -445,7 +446,7 @@
 
                 <tr>
                   <td>--h4-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-normal-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -453,7 +454,7 @@
 
                 <tr>
                   <td>--h4-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-normal-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -462,7 +463,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h5</th>
                   <td>--h5-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -470,7 +471,7 @@
 
                 <tr>
                   <td>--h5-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-small-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -478,7 +479,7 @@
 
                 <tr>
                   <td>--h5-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-small-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -486,7 +487,7 @@
 
                 <tr>
                   <td>--h5-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-small-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -494,7 +495,7 @@
 
                 <tr>
                   <td>--h5-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-small-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -502,7 +503,7 @@
 
                 <tr>
                   <td>--h5-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-small-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -511,7 +512,7 @@
                 <tr>
                   <th rowspan="6" scope="rowgroup">h6</th>
                   <td>--h6-font-family</td>
-                  <td><a href="../variables#font-family">font-family</a></td>
+                  <td><a href="{base}/variables#font-family">font-family</a></td>
                   <td>var(--headings-font-family)</td>
                   <td>-</td>
                   <td>-</td>
@@ -519,7 +520,7 @@
 
                 <tr>
                   <td>--h6-font-size</td>
-                  <td><a href="../variables#font-size">font-size</a></td>
+                  <td><a href="{base}/variables#font-size">font-size</a></td>
                   <td>var(--heading-xs-font-size)</td>
                   <td>-</td>
                   <td>-</td>
@@ -527,7 +528,7 @@
 
                 <tr>
                   <td>--h6-font-weight</td>
-                  <td><a href="../variables#font-weight">font-weight</a></td>
+                  <td><a href="{base}/variables#font-weight">font-weight</a></td>
                   <td>var(--heading-xs-font-weight)</td>
                   <td>-</td>
                   <td>-</td>
@@ -535,7 +536,7 @@
 
                 <tr>
                   <td>--h6-line-height</td>
-                  <td><a href="../variables#line-height">line-height</a></td>
+                  <td><a href="{base}/variables#line-height">line-height</a></td>
                   <td>var(--heading-xs-line-height)</td>
                   <td>-</td>
                   <td>-</td>
@@ -543,7 +544,7 @@
 
                 <tr>
                   <td>--h6-text-color</td>
-                  <td><a href="../variables#text-color">text-color</a></td>
+                  <td><a href="{base}/variables#text-color">text-color</a></td>
                   <td>var(--heading-xs-text-color)</td>
                   <td>-</td>
                   <td>-</td>
@@ -551,7 +552,7 @@
 
                 <tr>
                   <td>--h6-margin</td>
-                  <td><a href="../variables#margin">margin</a></td>
+                  <td><a href="{base}/variables#margin">margin</a></td>
                   <td>var(--heading-xs-margin)</td>
                   <td>-</td>
                   <td>-</td>
@@ -646,7 +647,7 @@
 
         <section id="related">
           <h2>Gerelateerde pagina's</h2>
-          <a href="./headings-test">Test- en voorbeelden-pagina</a>
+          <a href="{base}/components/headings-test">Test- en voorbeelden-pagina</a>
         </section>
       </section>
     </div>

--- a/docs/src/routes/(docs)/components/hidden/+page.svelte
+++ b/docs/src/routes/(docs)/components/hidden/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/horizontal-center/+page.svelte
+++ b/docs/src/routes/(docs)/components/horizontal-center/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -109,7 +110,7 @@
             <tbody>
               <tr>
                 <td>--horizontal-center-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--body-text-small-max-width)</td>
                 <td>-</td>
                 <td>horizontal-center</td>
@@ -135,7 +136,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./horizontal-center-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/horizontal-center-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/horizontal-scroll/+page.svelte
+++ b/docs/src/routes/(docs)/components/horizontal-scroll/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -439,7 +440,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -460,7 +461,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./horizontal-scroll-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/horizontal-scroll-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/horizontal-view/+page.svelte
+++ b/docs/src/routes/(docs)/components/horizontal-view/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -134,7 +135,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -153,16 +154,16 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#gap">gap</a></li>
+          <li><a href="{base}/variables#gap">gap</a></li>
           <li>
-            <a href="../variables#justify-content">justify-content</a>
+            <a href="{base}/variables#justify-content">justify-content</a>
           </li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./horizontal-view-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/horizontal-view-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/icons-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/icons-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -102,7 +103,7 @@
 
         <h3>Link als knop</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./icons-test" class="button icon icon-cat">Lorem ipsum</a>
+        <a href="{base}/components/icons-test" class="button icon icon-cat">Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -114,7 +115,7 @@
 
         <h3>Link als knop: disabled</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./icons-test" class="button icon icon-cat" disabled>Lorem ipsum</a>
+        <a href="{base}/components/icons-test" class="button icon icon-cat" disabled>Lorem ipsum</a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
@@ -126,35 +127,35 @@
 
         <h3>Link als knop icoon erachter</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./icons-test">Lorem ipsum<span class="icon icon-cat"></span></a>
+        <a href="{base}/components/icons-test">Lorem ipsum<span class="icon icon-cat"></span></a>
 
         <h4>HTML-voorbeeld:</h4>
         <Code
           language="html"
           code={`
-<a href="./icons-test" class="icon-after icon-cat">Lorem ipsum
+<a href="{base}/components/icons-test" class="icon-after icon-cat">Lorem ipsum
 `}
         />
 
         <h4>States</h4>
         <ul>
           <li>
-            <a href="./icons-test" class="button icon icon-cat focus">Focus</a>
+            <a href="{base}/components/icons-test" class="button icon icon-cat focus">Focus</a>
           </li>
           <li>
-            <a href="./icons-test" class="button icon icon-cat active">Active</a>
+            <a href="{base}/components/icons-test" class="button icon icon-cat active">Active</a>
           </li>
           <li>
-            <a href="./icons-test" class="button icon icon-cat visited">Visited</a>
+            <a href="{base}/components/icons-test" class="button icon icon-cat visited">Visited</a>
           </li>
           <li>
-            <a href="./icons-test" class="button icon icon-cat hover">Hover</a>
+            <a href="{base}/components/icons-test" class="button icon icon-cat hover">Hover</a>
           </li>
         </ul>
 
         <h3>Link als knop: met een afbeelding</h3>
         <h4>Visueel voorbeeld:</h4>
-        <a href="./icons-test" class="button icon icon-cat"
+        <a href="{base}/components/icons-test" class="button icon icon-cat"
           >Lorem ipsum <img src="$img/cat.svg" /></a
         >
 
@@ -264,16 +265,16 @@
         <h4>Visueel voorbeeld:</h4>
         <ul>
           <li>
-            <a href="./icons-test" class="icon icon-cat focus">Focus</a>
+            <a href="{base}/components/icons-test" class="icon icon-cat focus">Focus</a>
           </li>
           <li>
-            <a href="./icons-test" class="icon icon-cat active">Active</a>
+            <a href="{base}/components/icons-test" class="icon icon-cat active">Active</a>
           </li>
           <li>
-            <a href="./icons-test" class="icon icon-cat visited">Visited</a>
+            <a href="{base}/components/icons-test" class="icon icon-cat visited">Visited</a>
           </li>
           <li>
-            <a href="./icons-test" class="icon icon-cat hover">Hover</a>
+            <a href="{base}/components/icons-test" class="icon icon-cat hover">Hover</a>
           </li>
         </ul>
 
@@ -293,22 +294,22 @@
         <h4>Visueel voorbeeld:</h4>
         <ul>
           <li>
-            <a href="./icons-test" class="focus"
+            <a href="{base}/components/icons-test" class="focus"
               ><img src="$img/cat.svg" alt="Kat" class="icon" />Focus</a
             >
           </li>
           <li>
-            <a href="./icons-test" class="active"
+            <a href="{base}/components/icons-test" class="active"
               ><img src="$img/cat.svg" alt="Kat" class="icon" />Active</a
             >
           </li>
           <li>
-            <a href="./icons-test" class="visited"
+            <a href="{base}/components/icons-test" class="visited"
               ><img src="$img/cat.svg" alt="Kat" class="icon" />Visited</a
             >
           </li>
           <li>
-            <a href="./icons-test" class="hover"
+            <a href="{base}/components/icons-test" class="hover"
               ><img src="$img/cat.svg" alt="Kat" class="icon" />Hover</a
             >
           </li>

--- a/docs/src/routes/(docs)/components/icons/+page.svelte
+++ b/docs/src/routes/(docs)/components/icons/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -27,8 +28,8 @@
           <li>
             Voeg iconen toe aan het project.
             <ul>
-              <li><a href="./iconset-create">Iconset aanmaken</a></li>
-              <li><a href="./iconset-add">Iconset toevoegen</a></li>
+              <li><a href="{base}/components/iconset-create">Iconset aanmaken</a></li>
+              <li><a href="{base}/components/iconset-add">Iconset toevoegen</a></li>
             </ul>
           </li>
           <li>
@@ -70,7 +71,7 @@
         <p>
           <strong>Let op:</strong> Voeg eerst een iconenset toe aan het project met indien nodig een
           eigen referentielijst. Voor meer informatie zie:
-          <a href="./iconset-add">Iconset toevoegen</a>
+          <a href="{base}/components/iconset-add">Iconset toevoegen</a>
         </p>
 
         <h4>Visueel voorbeeld:</h4>
@@ -90,14 +91,14 @@
         <ol>
           <li>
             Voeg het icoonlettertype toe aan het project. Voor informatie zie:
-            <a href="./iconset-add">Icoonset toevoegen</a>.
+            <a href="{base}/components/iconset-add">Icoonset toevoegen</a>.
           </li>
           <li>
             Defineer het lettertype binnen het bestand
             <code>manon/icon/icon-base-variables</code> via de variabele
             <code>font-family</code>. Bijvoorbeeld:
             <code>--icon-font-family: "Manon icons";</code>. Zie ook
-            <a href="../import-styling#styling-override-variables"
+            <a href="{base}/import-styling#styling-override-variables"
               >De styling van een component aanpassen</a
             >.
           </li>
@@ -107,13 +108,13 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#font-family">font-family</a></li>
+          <li><a href="{base}/variables#font-family">font-family</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./icons-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/icons-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/iconset-add/+page.svelte
+++ b/docs/src/routes/(docs)/components/iconset-add/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -19,7 +20,7 @@
         <ol>
           <li>
             Maak een icoonlettertype of importeer een icoonlettertype. Voor meer informatie zie:
-            <a href="./iconset-create">Iconenset aanmaken</a>
+            <a href="{base}/components/iconset-create">Iconenset aanmaken</a>
           </li>
           <li>
             Bij een eigen icoonlettertype of bij het importeren van een iconenset zonder
@@ -29,7 +30,7 @@
           <li>
             Voeg bij een eigen opgestelde referentielijst het bestand toe aan het project via
             <code>manon.scss</code>. Voor meer informatie zie:
-            <a href="../import-styling">Styling importeren</a>.
+            <a href="{base}/import-styling">Styling importeren</a>.
           </li>
           <li>
             Voeg het icoonlettertype toe aan het project binnen:

--- a/docs/src/routes/(docs)/components/iconset-create/+page.svelte
+++ b/docs/src/routes/(docs)/components/iconset-create/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -24,7 +25,7 @@
           <li>
             Voeg het icoonlettertype toe aan het project binnen:
             <code>fonts.scss</code>. Voor meer informatie zie:
-            <a href="../add-fonts">Lettertype toevoegen</a>.
+            <a href="{base}/add-fonts">Lettertype toevoegen</a>.
           </li>
           <li>
             Maak een referentielijst voor het toevoegen van classes. Voor meer informatie zie:
@@ -33,7 +34,7 @@
           <li>
             Voeg de referentielijst toe aan het project via
             <code>manon.scss</code>. Voor meer informatie zie:
-            <a href="../import-styling">Styling importeren</a>.
+            <a href="{base}/import-styling">Styling importeren</a>.
           </li>
         </ol>
       </section>
@@ -64,7 +65,7 @@
           <li>
             Laad het nieuwe referentiebestand in binnen het project via
             <code>manon.scss</code>. Voor meer informatie zie:
-            <a href="../import-styling">Styling importeren</a>.
+            <a href="{base}/import-styling">Styling importeren</a>.
           </li>
           <li>
             Maak binnen de <code>:root</code> de css-variabelen aan met de referenties naar de
@@ -199,19 +200,19 @@
           <li>
             Voeg het icoonlettertype toe aan het project. Voor informatie over het toevoegen van een
             lettertype zie:
-            <a href="../add-fonts">Lettertype toevoegen</a>.
+            <a href="{base}/add-fonts">Lettertype toevoegen</a>.
           </li>
           <li>
             Voeg de referentie naar het lettertype toe via het
             <code>fonts.scss</code>-bestand.
-            <a href="../import-styling">Styling importeren</a>.
+            <a href="{base}/import-styling">Styling importeren</a>.
           </li>
           <li>
             Defineer het lettertype binnen het bestand
             <code>manon/icon/icon-base-variables</code> via de variabele
             <code>font-family</code>. Bijvoorbeeld:
             <code>--icon-font-family: "Manon icons";</code>. Zie ook
-            <a href="../import-styling#styling-override-variables"
+            <a href="{base}/import-styling#styling-override-variables"
               >De styling van een component aanpassen</a
             >.
           </li>

--- a/docs/src/routes/(docs)/components/image-cover-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/image-cover-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -53,7 +54,7 @@
         <h3>Op een tegel</h3>
         <p>
           Dit voorbeeld maakt gebruik van
-          <a href="./tiles#single-tile">Tegelweergave</a>.
+          <a href="{base}/components/tiles#single-tile">Tegelweergave</a>.
         </p>
         <div role="group" class="tile image-cover">
           <img src="$img/strand.jpg" alt="Foto van een strand" />
@@ -79,7 +80,7 @@
         <h3>Op een groep met tegels</h3>
         <p>
           Dit voorbeeld maakt gebruik van
-          <a href="./tiles">Tegelweergave</a>.
+          <a href="{base}/components/tiles">Tegelweergave</a>.
         </p>
         <div class="tiles image-covers column-3">
           <div role="group">

--- a/docs/src/routes/(docs)/components/image-cover/+page.svelte
+++ b/docs/src/routes/(docs)/components/image-cover/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -71,7 +72,7 @@
         <h3>Op een tegel</h3>
         <p>
           Dit voorbeeld maakt gebruik van
-          <a href="./tiles#single-tile">Tegelweergave</a>.
+          <a href="{base}/components/tiles#single-tile">Tegelweergave</a>.
         </p>
         <div role="group" class="tile image-cover">
           <img src="$img/strand.jpg" alt="Foto van een strand" />
@@ -97,7 +98,7 @@
         <h3>Op een groep met tegels</h3>
         <p>
           Dit voorbeeld maakt gebruik van
-          <a href="./tiles">Tegelweergave</a>.
+          <a href="{base}/components/tiles">Tegelweergave</a>.
         </p>
         <div class="tiles image-covers column-3">
           <div role="group">
@@ -159,7 +160,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -176,15 +177,15 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#object-position">object-position</a>
+            <a href="{base}/variables#object-position">object-position</a>
           </li>
-          <li><a href="../variables#max-height">max-height</a></li>
+          <li><a href="{base}/variables#max-height">max-height</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./image-cover-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/image-cover-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/image-round/+page.svelte
+++ b/docs/src/routes/(docs)/components/image-round/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -186,7 +187,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -203,15 +204,15 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#object-position">object-position</a>
+            <a href="{base}/variables#object-position">object-position</a>
           </li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./image-round-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/image-round-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/image-square/+page.svelte
+++ b/docs/src/routes/(docs)/components/image-square/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -186,7 +187,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -203,15 +204,15 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#object-position">object-position</a>
+            <a href="{base}/variables#object-position">object-position</a>
           </li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./image-square-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/image-square-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/language-selector/+page.svelte
+++ b/docs/src/routes/(docs)/components/language-selector/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -130,7 +131,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -161,7 +162,7 @@
             <tbody>
               <tr>
                 <td>--language-selector-list-label-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--de-emphasized-font-size)</td>
                 <td>-</td>
                 <td rowspan="34" scope="rowgroup">language</td>
@@ -169,231 +170,231 @@
 
               <tr>
                 <td>--language-selector-list-label-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--de-emphasized-text-color, inherit)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--de-emphasized-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--application-base-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>100%</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--grey-2)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>0px</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--application-base-background-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-link-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-link-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-link-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--grey-2)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-hover-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--branding-color-1-background-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-hover-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--branding-color-1-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-hover-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--language-selector-list-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-hover-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--language-selector-list-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-active-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--branding-color-2-background-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-active-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--branding-color-2-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-active-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--language-selector-list-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-item-active-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--language-selector-list-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--de-emphasized-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--de-emphasized-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--grey-2)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.125rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-padding-right</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.125rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-padding-left</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--language-selector-list-button-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>1.5rem</td>
                 <td>-</td>
               </tr>
@@ -469,7 +470,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./language-selector-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/language-selector-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-authentication/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-authentication/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -41,13 +42,13 @@
       <section id="variables">
         <h3>Instelbare variabelen</h3>
         <ul>
-          <li><a href="../variables#max-width">max-width</a></li>
-          <li><a href="../variables#padding">padding</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding">padding</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#text-color">text-color</a></li>
-          <li><a href="../variables#breakpoints">Breekpunten</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#breakpoints">Breekpunten</a></li>
         </ul>
       </section>
 
@@ -117,7 +118,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-authentication-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-authentication-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-base-options/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-base-options/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
 
@@ -106,7 +107,7 @@
           ingesteld worden. De onderliggende bestanden, layout-header, main en footer, zullen de
           instellingen volgen. Specifeke instellingen die binnen een van de onderliggende bestanden
           worden opgegeven overschrijven de centrale keuzes. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h4>Voorbeeld</h4>

--- a/docs/src/routes/(docs)/components/layout-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-base/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Basis-layout instellen";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Basis-layout instellen</title>
 </svelte:head>
@@ -16,14 +20,14 @@
           ingevuld worden die door alle hoofdelementen gebruikt worden zodra dit variabelen-bestand
           aanwezig is. Ieder hoofdelement heeft een eigen basisbestand waarbinnen unieke waardes
           ingevuld kunnen worden voor het specifieke element. Voor meer informatie zie
-          <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+          <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
         </p>
       </section>
 
       <section id="requirements">
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h2>Benodigd</h2>
         <ul>
@@ -45,23 +49,23 @@
             Algemene weergave:
             <ul>
               <li>
-                <a href="../variables#padding-top">padding-top</a>
+                <a href="{base}/variables#padding-top">padding-top</a>
               </li>
               <li>
-                <a href="../variables#padding-right">padding-right</a>
+                <a href="{base}/variables#padding-right">padding-right</a>
               </li>
               <li>
-                <a href="../variables#padding-bottom">padding-bottom</a>
+                <a href="{base}/variables#padding-bottom">padding-bottom</a>
               </li>
               <li>
-                <a href="../variables#padding-left">padding-left</a>
+                <a href="{base}/variables#padding-left">padding-left</a>
               </li>
-              <li><a href="../variables#max-width">max-width</a></li>
+              <li><a href="{base}/variables#max-width">max-width</a></li>
               <li>
                 Op titels en subtitels:
                 <ul>
                   <li>
-                    <a href="../variables#margin">margin</a>
+                    <a href="{base}/variables#margin">margin</a>
                   </li>
                 </ul>
               </li>
@@ -73,13 +77,13 @@
               <li>
                 Content-blok:
                 <ul>
-                  <li><a href="../variables#gap">gap</a></li>
+                  <li><a href="{base}/variables#gap">gap</a></li>
                 </ul>
               </li>
               <li>
                 Binnen dieper gelegen blok-elementen:
                 <ul>
-                  <li><a href="../variables#gap">gap</a></li>
+                  <li><a href="{base}/variables#gap">gap</a></li>
                 </ul>
               </li>
             </ul>

--- a/docs/src/routes/(docs)/components/layout-centered/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-centered/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -58,7 +59,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -79,7 +80,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-centered-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-centered-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-column-2/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-column-2/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -109,7 +110,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-column-2-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-column-2-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-column-3/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-column-3/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -130,7 +131,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-column-3-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-column-3-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-column-4/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-column-4/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -151,7 +152,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-column-4-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-column-4-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-fifty-fifty/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-fifty-fifty/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -124,7 +125,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -163,7 +164,7 @@
               <tbody>
                 <tr>
                   <td>--layout-fifty-fifty-gap</td>
-                  <td><a href="../variables#gap">gap</a></td>
+                  <td><a href="{base}/variables#gap">gap</a></td>
                   <td>var(--content-gap, 2rem)</td>
                   <td>42rem</td>
                   <td>-</td>
@@ -171,7 +172,7 @@
 
                 <tr>
                   <td>--layout-fifty-fifty-breakpoint-gap</td>
-                  <td><a href="../variables#gap">gap</a></td>
+                  <td><a href="{base}/variables#gap">gap</a></td>
                   <td>var(--layout-fifty-fifty-gap)</td>
                   <td>42rem</td>
                   <td>-</td>
@@ -204,7 +205,7 @@
 
         <section id="related">
           <h2>Gerelateerde pagina's</h2>
-          <a href="./layout-fifty-fifty-test">Test- en voorbeelden-pagina</a>
+          <a href="{base}/components/layout-fifty-fifty-test">Test- en voorbeelden-pagina</a>
         </section>
       </section>
     </div>

--- a/docs/src/routes/(docs)/components/layout-footer-content-block/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-footer-content-block/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -34,7 +35,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h2>Benodigde stappen:</h2>
@@ -43,7 +44,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -84,20 +85,20 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#min-height">min-height</a></li>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#min-height">min-height</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-footer/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-footer/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -33,7 +34,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h2>Benodigde stappen:</h2>
@@ -42,7 +43,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -64,7 +65,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -83,19 +84,19 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-form/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-form/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -18,7 +19,7 @@
         <p>Weergave opties voor pagina's met als formulieren als hoofdfunctie.</p>
         <p>
           Het is ook mogelijk om de weergave van alle formulieren aan te passen. Gebruik daarvoor: <a
-            href="./form-base">Basis formulieren</a
+            href="{base}/components/form-base">Basis formulieren</a
           >.
         </p>
 
@@ -108,7 +109,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -153,7 +154,7 @@
             <tbody>
               <tr>
                 <td>--layout-form-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--content-padding-top, 0)</td>
                 <td rowspan="5" scope="rowgroup">-</td>
                 <td rowspan="15" scope="rowgroup">layout-form</td>
@@ -161,87 +162,87 @@
 
               <tr>
                 <td>--layout-form-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right, 0)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom, 0)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left, 0)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>50rem</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-1-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--layout-form-padding-top)</td>
                 <td rowspan="5" scope="rowgroup">24rem</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-1-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--layout-form-padding-right)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-1-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--layout-form-padding-bottom)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-1-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--layout-form-padding-left)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-1-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--layout-form-max-width)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-2-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--layout-form-breakpoint-1-padding-top)</td>
                 <td rowspan="5" scope="rowgroup">42rem</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-2-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--layout-form-breakpoint-1-padding-right)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-2-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--layout-form-breakpoint-1-padding-bottom)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-2-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--layout-form-breakpoint-1-padding-left)</td>
               </tr>
 
               <tr>
                 <td>--layout-form-breakpoint-2-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--layout-form-breakpoint-1-max-width)</td>
               </tr>
             </tbody>

--- a/docs/src/routes/(docs)/components/layout-header-content-block/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-header-content-block/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -34,7 +35,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h2>Benodigde stappen:</h2>
@@ -43,7 +44,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -84,19 +85,19 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-header/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-header/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -33,7 +34,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h2>Benodigde stappen:</h2>
@@ -42,7 +43,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -64,7 +65,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -83,19 +84,19 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-main-content-block/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-main-content-block/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -34,7 +35,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h3>Benodigde stappen:</h3>
@@ -43,7 +44,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -65,7 +66,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -84,20 +85,20 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Eerste element:
             <ul>
               <li>
-                <a href="../variables#padding-top">padding-top</a>
+                <a href="{base}/variables#padding-top">padding-top</a>
               </li>
             </ul>
           </li>
@@ -105,14 +106,14 @@
             Laatste element:
             <ul>
               <li>
-                <a href="../variables#padding-bottom">padding-bottom</a>
+                <a href="{base}/variables#padding-bottom">padding-bottom</a>
               </li>
             </ul>
           </li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-main/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-main/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -33,7 +34,7 @@
           <code>layout-base-variables.scss</code> indien dit aanwezig is. Als de header, main en
           footer stijlkeuzes delen is het efficient om de keuzes in te stellen in dat bestand om
           herhaling en inconsitentie te voorkomen. Voor meer informatie zie:
-          <a href="./layout-base">Basisweergave instellen</a>.
+          <a href="{base}/components/layout-base">Basisweergave instellen</a>.
         </p>
 
         <h2>Benodigde stappen:</h2>
@@ -42,7 +43,7 @@
             Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
             <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
             juiste weergave en het instellen ervan zie:
-            <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+            <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -64,7 +65,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -83,20 +84,20 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
           <li>
             Eerste element:
             <ul>
               <li>
-                <a href="../variables#padding-top">padding-top</a>
+                <a href="{base}/variables#padding-top">padding-top</a>
               </li>
             </ul>
           </li>
@@ -104,14 +105,14 @@
             Laatste element:
             <ul>
               <li>
-                <a href="../variables#padding-bottom">padding-bottom</a>
+                <a href="{base}/variables#padding-bottom">padding-bottom</a>
               </li>
             </ul>
           </li>
           <li>
             Top level blokken en onderliggende blokken:
             <ul>
-              <li><a href="../variables#gap">gap</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
             </ul>
           </li>
         </ul>

--- a/docs/src/routes/(docs)/components/layout-one-third-two-thirds/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-one-third-two-thirds/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -118,7 +119,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -167,7 +168,7 @@
             <tbody>
               <tr>
                 <td>--layout-one-third-two-thirds-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--content-gap)</td>
                 <td>42rem</td>
                 <td>one-third-two-thirds</td>
@@ -193,7 +194,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-one-third-two-thirds-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-one-third-two-thirds-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layout-set/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-set/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -42,7 +43,7 @@
               <li>
                 Pas de layoutkeuzes toe waar nodig. De layoutkeuzes kunnen door middel van
                 variabelen binnen de CSS worden toegevoegd. Voor meer informatie hierover zie <a
-                  href="../use-css-variable">CSS-variabelen gebruiken</a
+                  href="{base}/use-css-variable">CSS-variabelen gebruiken</a
                 >.
               </li>
             </ul>
@@ -69,7 +70,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -79,7 +80,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -142,7 +143,7 @@
 
               <tr>
                 <td>--content-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>column</td>
                 <td>-</td>
                 <td>-</td>
@@ -150,7 +151,7 @@
 
               <tr>
                 <td>--content-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>flex-start</td>
                 <td>-</td>
                 <td>-</td>
@@ -158,7 +159,7 @@
 
               <tr>
                 <td>--content-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>flex-start</td>
                 <td>-</td>
                 <td>-</td>
@@ -166,7 +167,7 @@
 
               <tr>
                 <td>--content-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>2rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -174,7 +175,7 @@
 
               <tr>
                 <td>--content-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>2rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -182,7 +183,7 @@
 
               <tr>
                 <td>--content-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -190,7 +191,7 @@
 
               <tr>
                 <td>--content-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>2rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -198,7 +199,7 @@
 
               <tr>
                 <td>--content-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -206,7 +207,7 @@
 
               <tr>
                 <td>--content-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/layout-two-thirds-one-third/+page.svelte
+++ b/docs/src/routes/(docs)/components/layout-two-thirds-one-third/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -118,7 +119,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -167,7 +168,7 @@
             <tbody>
               <tr>
                 <td>--layout-two-thirds-one-third-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--content-gap)</td>
                 <td>42rem</td>
                 <td>two-thirds-one-third</td>
@@ -193,7 +194,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./layout-two-thirds-one-third-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/layout-two-thirds-one-third-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/layouts/+page.svelte
+++ b/docs/src/routes/(docs)/components/layouts/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Layouts";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Layouts</title>
 </svelte:head>
@@ -18,7 +22,7 @@
           Kies de gewenste basisweergaven. Voor beschikbare weergaven zie:
           <a href="#layout-base">Basis-weergave</a>. Voor meer informatie over het kiezen van de
           juiste weergave en het instellen ervan zie:
-          <a href="./layout-base-options">Basisweergave kiezen en instellen</a>.
+          <a href="{base}/components/layout-base-options">Basisweergave kiezen en instellen</a>.
         </li>
         <li>
           Kies de gewenste uitzonderingsweergaven. Voor beschikbare weergaven zie:
@@ -39,30 +43,30 @@
             <li>
               Basis-weergave direct:
               <ul>
-                <li><a href="./layout-header">Layout header</a></li>
-                <li><a href="./layout-main">Layout main</a></li>
-                <li><a href="./layout-footer">Layout footer</a></li>
+                <li><a href="{base}/components/layout-header">Layout header</a></li>
+                <li><a href="{base}/components/layout-main">Layout main</a></li>
+                <li><a href="{base}/components/layout-footer">Layout footer</a></li>
               </ul>
             </li>
             <li>
               Basis-weergave op contentblokken:
               <ul>
                 <li>
-                  <a href="./layout-header-content-block">Layout header contentblok</a>
+                  <a href="{base}/components/layout-header-content-block">Layout header contentblok</a>
                 </li>
                 <li>
-                  <a href="./layout-main-content-block">Layout main contentblok</a>
+                  <a href="{base}/components/layout-main-content-block">Layout main contentblok</a>
                 </li>
                 <li>
-                  <a href="./layout-footer-content-block">Layout footer contentblok</a>
+                  <a href="{base}/components/layout-footer-content-block">Layout footer contentblok</a>
                 </li>
               </ul>
             </li>
             <li>
               Op attributen:
               <ul>
-                <li><a href="./section">Layout sectie</a></li>
-                <li><a href="./article">Layout artikel</a></li>
+                <li><a href="{base}/components/section">Layout sectie</a></li>
+                <li><a href="{base}/components/article">Layout artikel</a></li>
               </ul>
             </li>
           </ul>
@@ -72,22 +76,22 @@
           <h3 id="layout-types">Uitzonderingsweergaven</h3>
           <ul>
             <li>
-              <a href="./layout-authentication">Authentication</a>
+              <a href="{base}/components/layout-authentication">Authentication</a>
             </li>
             <li>
-              <a href="./layout-one-third-two-thirds">Eenderde tweederde </a>
+              <a href="{base}/components/layout-one-third-two-thirds">Eenderde tweederde </a>
             </li>
             <li>
-              <a href="./layout-two-thirds-one-third">Tweederde eenderde</a>
+              <a href="{base}/components/layout-two-thirds-one-third">Tweederde eenderde</a>
             </li>
-            <li><a href="./layout-fifty-fifty">50/50</a></li>
-            <li><a href="./layout-centered">Gecentreerd</a></li>
+            <li><a href="{base}/components/layout-fifty-fifty">50/50</a></li>
+            <li><a href="{base}/components/layout-centered">Gecentreerd</a></li>
             <li>
-              <a href="./layout-form">Formulieren</a>
+              <a href="{base}/components/layout-form">Formulieren</a>
             </li>
-            <li><a href="./layout-column-2">Twee kolommen</a></li>
-            <li><a href="./layout-column-3">Drie kolommen</a></li>
-            <li><a href="./layout-column-4">Vier kolommen</a></li>
+            <li><a href="{base}/components/layout-column-2">Twee kolommen</a></li>
+            <li><a href="{base}/components/layout-column-3">Drie kolommen</a></li>
+            <li><a href="{base}/components/layout-column-4">Vier kolommen</a></li>
           </ul>
         </div>
       </div>

--- a/docs/src/routes/(docs)/components/link/+page.svelte
+++ b/docs/src/routes/(docs)/components/link/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -105,7 +106,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -150,7 +151,7 @@
             <tbody>
               <tr>
                 <td>--link-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">links</td>
@@ -158,14 +159,14 @@
 
               <tr>
                 <td>--link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>#2f2f9a</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--link-text-decoration</td>
-                <td><a href="../variables#text-decoration">text-decoration</a></td>
+                <td><a href="{base}/variables#text-decoration">text-decoration</a></td>
                 <td>initial</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/login-meta/+page.svelte
+++ b/docs/src/routes/(docs)/components/login-meta/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -46,7 +47,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -64,30 +65,30 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#flex-direction">flex-direction</a>
+            <a href="{base}/variables#flex-direction">flex-direction</a>
           </li>
           <li>
-            <a href="../variables#justify-content">justify-content</a>
+            <a href="{base}/variables#justify-content">justify-content</a>
           </li>
-          <li><a href="../variables#align-items">align-items</a></li>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#align-items">align-items</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
-          <li><a href="../variables#gap">gap</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#gap">gap</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./login-meta-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/login-meta-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/logo/+page.svelte
+++ b/docs/src/routes/(docs)/components/logo/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -22,7 +23,7 @@
         <h3>Visuele voorbeeld:</h3>
 
         <a
-          href="./logo"
+          href="{base}/components/logo"
           class="logo"
           aria-label="Logo bedrijfs- of product-naam, ga naar de homepage van bedrijfs- of product-naam"
         >
@@ -34,7 +35,7 @@
         <Code
           language="html"
           code={`
-<a href="./logo" class="logo" aria-label="Logo bedrijfs- of product-naam, ga naar de homepage van bedrijfs- of product-naam">
+<a href="{base}/components/logo" class="logo" aria-label="Logo bedrijfs- of product-naam, ga naar de homepage van bedrijfs- of product-naam">
   <img src="/logo.svg" alt="Logo bedrijfs- of product-naam" />
   Bedrijfs- of product-naam
 </a>
@@ -53,16 +54,16 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#width">width</a></li>
-          <li><a href="../variables#min-width">min-width</a></li>
-          <li><a href="../variables#max-width">max-width</a></li>
-          <li><a href="../variables#height">height</a></li>
-          <li><a href="../variables#min-height">min-height</a></li>
-          <li><a href="../variables#max-height">max-height</a></li>
+          <li><a href="{base}/variables#width">width</a></li>
+          <li><a href="{base}/variables#min-width">min-width</a></li>
+          <li><a href="{base}/variables#max-width">max-width</a></li>
+          <li><a href="{base}/variables#height">height</a></li>
+          <li><a href="{base}/variables#min-height">min-height</a></li>
+          <li><a href="{base}/variables#max-height">max-height</a></li>
           <li>
-            <a href="../variables#object-position">object-position</a>
+            <a href="{base}/variables#object-position">object-position</a>
           </li>
-          <li><a href="../variables#object-fit">object-fit</a></li>
+          <li><a href="{base}/variables#object-fit">object-fit</a></li>
         </ul>
       </section>
     </div>

--- a/docs/src/routes/(docs)/components/main-content-wrapper/+page.svelte
+++ b/docs/src/routes/(docs)/components/main-content-wrapper/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -106,7 +107,7 @@
             <tbody>
               <tr>
                 <td>--main-content-wrapper-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -114,7 +115,7 @@
 
               <tr>
                 <td>--main-content-wrapper-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -122,7 +123,7 @@
 
               <tr>
                 <td>--main-content-wrapper-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -130,7 +131,7 @@
 
               <tr>
                 <td>--main-content-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -138,7 +139,7 @@
 
               <tr>
                 <td>--main-content-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -146,7 +147,7 @@
 
               <tr>
                 <td>--main-content-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -154,7 +155,7 @@
 
               <tr>
                 <td>--main-content-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -162,7 +163,7 @@
 
               <tr>
                 <td>--main-content-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -170,7 +171,7 @@
 
               <tr>
                 <td>--main-content-wrapper-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -205,8 +206,8 @@
         <h2>Gerelateerde pagina's</h2>
         <nav aria-label="Gerelateerde pagina's">
           <ul>
-            <li><a href="./main-test">Test- en voorbeelden-pagina</a></li>
-            <li><a href="./main-content-wrapper">Main content wrapper</a></li>
+            <li><a href="{base}/components/main-test">Test- en voorbeelden-pagina</a></li>
+            <li><a href="{base}/components/main-content-wrapper">Main content wrapper</a></li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/main-test-content-wrapper-div/+page.svelte
+++ b/docs/src/routes/(docs)/components/main-test-content-wrapper-div/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -37,7 +38,7 @@
       <h2>Gebruikte bestanden</h2>
       <p>
         Voor meer informatie over importeren en instellen van componenten. Zie: <a
-          href="../import-styling">Componenten gebruiken en styling toevoegen</a
+          href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
         >
       </p>
 

--- a/docs/src/routes/(docs)/components/main-test-direct/+page.svelte
+++ b/docs/src/routes/(docs)/components/main-test-direct/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -28,7 +29,7 @@
   <h2>Gebruikte bestanden</h2>
   <p>
     Voor meer informatie over importeren en instellen van componenten. Zie: <a
-      href="../import-styling">Componenten gebruiken en styling toevoegen</a
+      href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
     >
   </p>
 

--- a/docs/src/routes/(docs)/components/main-test-div/+page.svelte
+++ b/docs/src/routes/(docs)/components/main-test-div/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -33,7 +34,7 @@
     <h2>Gebruikte bestanden</h2>
     <p>
       Voor meer informatie over importeren en instellen van componenten. Zie: <a
-        href="../import-styling">Componenten gebruiken en styling toevoegen</a
+        href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
       >
     </p>
 

--- a/docs/src/routes/(docs)/components/main/+page.svelte
+++ b/docs/src/routes/(docs)/components/main/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -72,7 +73,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -104,7 +105,7 @@
             <tbody>
               <tr>
                 <td>--main-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -112,7 +113,7 @@
 
               <tr>
                 <td>--main-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -120,7 +121,7 @@
 
               <tr>
                 <td>--main-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -128,7 +129,7 @@
 
               <tr>
                 <td>--main-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -136,7 +137,7 @@
 
               <tr>
                 <td>--main-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -144,7 +145,7 @@
 
               <tr>
                 <td>--main-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -152,7 +153,7 @@
 
               <tr>
                 <td>--main-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -160,7 +161,7 @@
 
               <tr>
                 <td>--main-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -201,7 +202,7 @@
               <code>div</code>'s.
             </li>
             <li>
-              <a href="./main-content-wrapper">Main content wrapper</a>: Content binnen een content
+              <a href="{base}/components/main-content-wrapper">Main content wrapper</a>: Content binnen een content
               wrapper.
             </li>
           </ul>

--- a/docs/src/routes/(docs)/components/max-line-length/+page.svelte
+++ b/docs/src/routes/(docs)/components/max-line-length/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -82,7 +83,7 @@
                 <td>max-width</td>
                 <td>-</td>
                 <td>--max-line-length-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>-</td>
                 <td>40rem</td>
               </tr>
@@ -91,7 +92,7 @@
                 <td rowspan="2" scope="rowgroup">hyphens</td>
                 <td>Voor breekpunt</td>
                 <td>--max-line-length-hyphens</td>
-                <td rowspan="2" scope="rowgroup"><a href="../variables#hyphens">hyphens</a></td>
+                <td rowspan="2" scope="rowgroup"><a href="{base}/variables#hyphens">hyphens</a></td>
                 <td rowspan="2" scope="rowgroup">-</td>
                 <td>auto</td>
               </tr>
@@ -107,7 +108,7 @@
                 <td>Voor breekpunt</td>
                 <td>--max-line-length-word-break</td>
                 <td rowspan="2" scope="rowgroup"
-                  ><a href="../variables#word-break">word-break</a></td
+                  ><a href="{base}/variables#word-break">word-break</a></td
                 >
                 <td rowspan="2" scope="rowgroup">-</td>
                 <td>normal</td>
@@ -146,7 +147,7 @@
         <p>Voeg de (s)css-bestanden toe aan het project of importeer de bestanden.</p>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/message-counter/+page.svelte
+++ b/docs/src/routes/(docs)/components/message-counter/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -89,20 +90,20 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#padding">padding</a></li>
+          <li><a href="{base}/variables#padding">padding</a></li>
           <li>
-            <a href="../variables#border-radius">border-radius</a>
+            <a href="{base}/variables#border-radius">border-radius</a>
           </li>
-          <li><a href="../variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#text-color">text-color</a></li>
-          <li><a href="../variables#height">height</a></li>
-          <li><a href="../variables#min-width">min-width</a></li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#height">height</a></li>
+          <li><a href="{base}/variables#min-width">min-width</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
         </ul>
       </section>
 

--- a/docs/src/routes/(docs)/components/navigation/+page.svelte
+++ b/docs/src/routes/(docs)/components/navigation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -248,7 +249,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -293,7 +294,7 @@
             <tbody>
               <tr>
                 <td>--links-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--body-text-small-font-size)</td>
                 <td>-</td>
                 <td rowspan="4" scope="rowgroup">links</td>
@@ -301,21 +302,21 @@
 
               <tr>
                 <td>--links-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--body-text-small-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--links-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--body-text-small-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--links-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--body-text-small-color)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/nota-bene/+page.svelte
+++ b/docs/src/routes/(docs)/components/nota-bene/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -92,7 +93,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -109,21 +110,21 @@
       <section id="variables">
         <h2>Instelbare variabelen</h2>
         <ul>
-          <li><a href="../variables#line-height">line-height</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#font-weight">font-weight</a></li>
-          <li><a href="../variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#line-height">line-height</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#font-weight">font-weight</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
         </ul>
 
         <p>Bijbehorende elementen:</p>
         <ul>
-          <li><a href="./form-base">form-base</a></li>
+          <li><a href="{base}/components/form-base">form-base</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./nota-bene-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/nota-bene-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/notification-attention/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-attention/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="attention-paragraph">Paragraaf</h3>
@@ -694,7 +695,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notification-confirmation/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-confirmation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="confirmation-paragraph">Paragraaf</h3>
@@ -702,7 +703,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notification-error/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-error/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="error-paragraph">Paragraaf</h3>
@@ -694,7 +695,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notification-explanation/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-explanation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="explanation-paragraph">Paragraaf</h3>
@@ -700,7 +701,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notification-system-message/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-system-message/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="system-paragraph">Paragraaf</h3>
@@ -702,7 +703,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notification-warning/+page.svelte
+++ b/docs/src/routes/(docs)/components/notification-warning/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -78,7 +79,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de benodigde HTML toe. Zie het voorbeeld per element voor de implementatiedetails.
@@ -170,7 +171,7 @@
 
         <p>
           Voor meer informatie zie:
-          <a href="./notifications-block-element">Blok-element</a>
+          <a href="{base}/components/notifications-block-element">Blok-element</a>
         </p>
 
         <h3 id="warning-paragraph">Paragraaf</h3>
@@ -698,7 +699,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/notifications-block-element/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-block-element/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -166,7 +167,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -187,7 +188,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./notifications-block-element-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/notifications-block-element-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/notifications-page-example-confirmation/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-page-example-confirmation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -45,7 +46,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -78,7 +79,7 @@
             <tbody>
               <tr>
                 <td>--notification-confirmation-page-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--confirmation-background-color)</td>
                 <td>-</td>
                 <td rowspan="24" scope="rowgroup">confirmation</td>
@@ -86,161 +87,161 @@
 
               <tr>
                 <td>--notification-confirmation-page-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--confirmation-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--notification-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--notification-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--confirmation-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-confirmation-page-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-span-font-weight</td>
-                <td><a href="../variables#span-font-weight">span-font-weight</a></td>
+                <td><a href="{base}/variables#span-font-weight">span-font-weight</a></td>
                 <td>var(--notification-span-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-pagecontent-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-pagecontent-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-confirmation-pagecontent-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-pagecontent-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-pagecontent-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-pagecontent-wrapper-span-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--notification-icon-font-family)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--notification-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--notification-icon-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--notification-icon-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--notification-icon-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon-margin-right</td>
-                <td><a href="../variables#margin-right">margin-right</a></td>
+                <td><a href="{base}/variables#margin-right">margin-right</a></td>
                 <td>var(--notification-icon-margin-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-confirmation-page-icon</td>
-                <td><a href="../variables#content">content</a></td>
+                <td><a href="{base}/variables#content">content</a></td>
                 <td>var(--notification-icon)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/notifications-page-example-error/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-page-example-error/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -45,7 +46,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -78,7 +79,7 @@
             <tbody>
               <tr>
                 <td>--notification-error-page-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--error-background-color)</td>
                 <td>-</td>
                 <td rowspan="24" scope="rowgroup">error</td>
@@ -86,161 +87,161 @@
 
               <tr>
                 <td>--notification-error-page-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--error-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--notification-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--notification-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--error-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-error-page-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-span-font-weight</td>
-                <td><a href="../variables#span-font-weight">span-font-weight</a></td>
+                <td><a href="{base}/variables#span-font-weight">span-font-weight</a></td>
                 <td>var(--notification-span-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-pagecontent-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-pagecontent-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-error-pagecontent-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-pagecontent-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-pagecontent-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-pagecontent-wrapper-span-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--notification-icon-font-family)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--notification-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--notification-icon-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--notification-icon-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--notification-icon-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon-margin-right</td>
-                <td><a href="../variables#margin-right">margin-right</a></td>
+                <td><a href="{base}/variables#margin-right">margin-right</a></td>
                 <td>var(--notification-icon-margin-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-error-page-icon</td>
-                <td><a href="../variables#content">content</a></td>
+                <td><a href="{base}/variables#content">content</a></td>
                 <td>var(--notification-icon)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/notifications-page-example-explanation/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-page-example-explanation/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -45,7 +46,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -78,7 +79,7 @@
             <tbody>
               <tr>
                 <td>--notification-explanation-page-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--explanation-background-color)</td>
                 <td>-</td>
                 <td rowspan="24" scope="rowgroup">explanation</td>
@@ -86,161 +87,161 @@
 
               <tr>
                 <td>--notification-explanation-page-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--explanation-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--notification-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--notification-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--explanation-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-explanation-page-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-span-font-weight</td>
-                <td><a href="../variables#span-font-weight">span-font-weight</a></td>
+                <td><a href="{base}/variables#span-font-weight">span-font-weight</a></td>
                 <td>var(--notification-span-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-pagecontent-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-pagecontent-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-explanation-pagecontent-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-pagecontent-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-pagecontent-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-pagecontent-wrapper-span-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--notification-icon-font-family)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--notification-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--notification-icon-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--notification-icon-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--notification-icon-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon-margin-right</td>
-                <td><a href="../variables#margin-right">margin-right</a></td>
+                <td><a href="{base}/variables#margin-right">margin-right</a></td>
                 <td>var(--notification-icon-margin-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-explanation-page-icon</td>
-                <td><a href="../variables#content">content</a></td>
+                <td><a href="{base}/variables#content">content</a></td>
                 <td>var(--notification-icon)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/notifications-page-example-system/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-page-example-system/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -45,7 +46,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -78,7 +79,7 @@
             <tbody>
               <tr>
                 <td>--notification-system-page-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--system-background-color)</td>
                 <td>-</td>
                 <td rowspan="24" scope="rowgroup">system</td>
@@ -86,161 +87,161 @@
 
               <tr>
                 <td>--notification-system-page-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--system-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--notification-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--notification-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--system-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-system-page-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-span-font-weight</td>
-                <td><a href="../variables#span-font-weight">span-font-weight</a></td>
+                <td><a href="{base}/variables#span-font-weight">span-font-weight</a></td>
                 <td>var(--notification-span-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-pagecontent-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-pagecontent-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-system-pagecontent-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-pagecontent-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-pagecontent-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-pagecontent-wrapper-span-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--notification-icon-font-family)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--notification-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--notification-icon-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--notification-icon-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--notification-icon-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon-margin-right</td>
-                <td><a href="../variables#margin-right">margin-right</a></td>
+                <td><a href="{base}/variables#margin-right">margin-right</a></td>
                 <td>var(--notification-icon-margin-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-system-page-icon</td>
-                <td><a href="../variables#content">content</a></td>
+                <td><a href="{base}/variables#content">content</a></td>
                 <td>var(--notification-icon)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/notifications-page-example-warning/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-page-example-warning/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -45,7 +46,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -78,7 +79,7 @@
             <tbody>
               <tr>
                 <td>--notification-warning-page-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--warning-background-color)</td>
                 <td>-</td>
                 <td rowspan="24" scope="rowgroup">warning</td>
@@ -86,161 +87,161 @@
 
               <tr>
                 <td>--notification-warning-page-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--warning-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--notification-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--notification-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--warning-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-warning-page-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-span-font-weight</td>
-                <td><a href="../variables#span-font-weight">span-font-weight</a></td>
+                <td><a href="{base}/variables#span-font-weight">span-font-weight</a></td>
                 <td>var(--notification-span-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-pagecontent-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-pagecontent-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td> --notification-warning-pagecontent-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-pagecontent-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-pagecontent-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-pagecontent-wrapper-span-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-font-family</td>
-                <td><a href="../variables#font-family">font-family</a></td>
+                <td><a href="{base}/variables#font-family">font-family</a></td>
                 <td>var(--notification-icon-font-family)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--notification-icon-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
                 <td>var(--notification-icon-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--notification-icon-padding-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--notification-icon-padding-left)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon-margin-right</td>
-                <td><a href="../variables#margin-right">margin-right</a></td>
+                <td><a href="{base}/variables#margin-right">margin-right</a></td>
                 <td>var(--notification-icon-margin-right)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--notification-warning-page-icon</td>
-                <td><a href="../variables#content">content</a></td>
+                <td><a href="{base}/variables#content">content</a></td>
                 <td>var(--notification-icon)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/notifications-paragraph/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-paragraph/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -95,7 +96,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -134,16 +135,16 @@
             Paragraaf variabelen
             <ul>
               <li>
-                <a href="../variables#padding-top">padding-top</a>
+                <a href="{base}/variables#padding-top">padding-top</a>
               </li>
               <li>
-                <a href="../variables#padding-right">padding-right</a>
+                <a href="{base}/variables#padding-right">padding-right</a>
               </li>
               <li>
-                <a href="../variables#padding-bottom">padding-bottom</a>
+                <a href="{base}/variables#padding-bottom">padding-bottom</a>
               </li>
               <li>
-                <a href="../variables#padding-left">padding-left</a>
+                <a href="{base}/variables#padding-left">padding-left</a>
               </li>
             </ul>
           </li>
@@ -152,7 +153,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./notifications-paragraph-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/notifications-paragraph-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/notifications-table/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications-table/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
 
@@ -77,10 +78,10 @@
           <nav id="notification-table-types">
             <ul>
               <li>
-                <a href="./notification-confirmation">Tabelrij <code>tr</code></a>
+                <a href="{base}/components/notification-confirmation">Tabelrij <code>tr</code></a>
               </li>
               <li>
-                <a href="./notification-warning">Tabelcel <code>td</code></a>
+                <a href="{base}/components/notification-warning">Tabelcel <code>td</code></a>
               </li>
             </ul>
           </nav>

--- a/docs/src/routes/(docs)/components/notifications/+page.svelte
+++ b/docs/src/routes/(docs)/components/notifications/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Notificaties";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Notificaties</title>
 </svelte:head>
@@ -37,18 +41,18 @@
           <nav id="notification-types">
             <h3>Notificatie-types</h3>
             <ul>
-              <li><a href="./notification-error">Foutmelding</a></li>
+              <li><a href="{base}/components/notification-error">Foutmelding</a></li>
               <li>
-                <a href="./notification-warning">Waarschuwing</a>
+                <a href="{base}/components/notification-warning">Waarschuwing</a>
               </li>
               <li>
-                <a href="./notification-confirmation">Bevestiging</a>
+                <a href="{base}/components/notification-confirmation">Bevestiging</a>
               </li>
               <li>
-                <a href="./notification-explanation">Toelichting</a>
+                <a href="{base}/components/notification-explanation">Toelichting</a>
               </li>
               <li>
-                <a href="./notification-system-message">Systeemberichten</a>
+                <a href="{base}/components/notification-system-message">Systeemberichten</a>
               </li>
             </ul>
           </nav>
@@ -57,13 +61,13 @@
             <h3>Weergaven</h3>
             <ul>
               <li>
-                <a href="./notifications-block-element">Blokelement</a>
+                <a href="{base}/components/notifications-block-element">Blokelement</a>
               </li>
               <li>
-                <a href="./notifications-paragraph">Paragraaf</a>
+                <a href="{base}/components/notifications-paragraph">Paragraaf</a>
               </li>
-              <li><a href="./notifications-table">Tabel</a></li>
-              <li><a href="./notifications-page">Pagina-notificatie</a></li>
+              <li><a href="{base}/components/notifications-table">Tabel</a></li>
+              <li><a href="{base}/components/notifications-page">Pagina-notificatie</a></li>
             </ul>
           </nav>
         </div>

--- a/docs/src/routes/(docs)/components/nowrap-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/nowrap-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -23,7 +24,7 @@
         <h3><dfn>nowrap</dfn> op een <code>p</code></h3>
         <p class="explanation">
           <span>Toelichting:</span> In dit voorbeeld wordt er ook gebruik gemaakt van de
-          <dfn>helper-class</dfn> <a href="./horizontal-scroll">horizontal-scroll</a> om te
+          <dfn>helper-class</dfn> <a href="{base}/components/horizontal-scroll">horizontal-scroll</a> om te
           voorkomen dat het voorbeeld-element de layout van de pagina breekt. Zonder deze toevoeging
           zou de tekst het scherm uitlopen. De class <code>horizontal-scroll</code> voegt op de maximale
           beschikbare breedte de scrollbalk toe.

--- a/docs/src/routes/(docs)/components/nowrap/+page.svelte
+++ b/docs/src/routes/(docs)/components/nowrap/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -48,7 +49,7 @@
           <code>table</code>
           of de omliggende <code>div</code> zullen alle onderliggende tekst-elementen niet afbreken.
           Verschillende voorbeelden en opties zijn beschikbaar op de
-          <a href="./nowrap-test">Test- en voorbeelden-pagina</a>.
+          <a href="{base}/components/nowrap-test">Test- en voorbeelden-pagina</a>.
         </p>
       </section>
 
@@ -57,7 +58,7 @@
         <h3>Basis</h3>
         <p class="explanation">
           <span>Toelichting:</span> In dit voorbeeld wordt er ook gebruik gemaakt van de
-          <dfn>helper-class</dfn> <a href="./horizontal-scroll">horizontal-scroll</a> om te
+          <dfn>helper-class</dfn> <a href="{base}/components/horizontal-scroll">horizontal-scroll</a> om te
           voorkomen dat het voorbeeld-element de layout van de pagina breekt. Zonder deze toevoeging
           zou de tekst het scherm uitlopen. De class <code>horizontal-scroll</code> voegt op de maximale
           beschikbare breedte de scrollbalk toe.
@@ -165,7 +166,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Benodigd</h3>
@@ -181,7 +182,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./nowrap-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/nowrap-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/pagination/+page.svelte
+++ b/docs/src/routes/(docs)/components/pagination/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -110,7 +111,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -221,7 +222,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./pagination-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/pagination-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/paragraph/+page.svelte
+++ b/docs/src/routes/(docs)/components/paragraph/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -40,7 +41,7 @@
         <p>
           Voor leesbaarheid en toegankelijkheid wordt aangeraden om de maximale regellengte te
           beperken tot 80 karakters. Voor meer informatie zie:
-          <a href="./max-line-length">maximale regellengte</a> en
+          <a href="{base}/components/max-line-length">maximale regellengte</a> en
           <a href="https://www.w3.org/TR/WCAG21/#visual-presentation" rel="external"
             >w3.org - Success Criterion 1.4.8 Visual Presentation</a
           >.
@@ -75,7 +76,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -107,7 +108,7 @@
             <tbody>
               <tr>
                 <td>--p-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--application-base-line-height)</td>
                 <td>-</td>
                 <td>-</td>
@@ -115,7 +116,7 @@
 
               <tr>
                 <td>--p-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--application-base-font-size)</td>
                 <td>-</td>
                 <td>-</td>
@@ -123,7 +124,7 @@
 
               <tr>
                 <td>--p-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--application-base-font-weight)</td>
                 <td>-</td>
                 <td>-</td>
@@ -131,7 +132,7 @@
 
               <tr>
                 <td>--p-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -139,7 +140,7 @@
 
               <tr>
                 <td>--p-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>unset</td>
                 <td>-</td>
                 <td>-</td>
@@ -169,7 +170,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./paragraph-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/paragraph-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/section-content-wrapper-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/section-content-wrapper-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -36,7 +37,7 @@
         <h2>Gebruikte bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie: <a
-            href="../import-styling">Componenten gebruiken en styling toevoegen</a
+            href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
           >
         </p>
 

--- a/docs/src/routes/(docs)/components/section-content-wrapper/+page.svelte
+++ b/docs/src/routes/(docs)/components/section-content-wrapper/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -74,7 +75,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -106,7 +107,7 @@
             <tbody>
               <tr>
                 <td>--section-content-wrapper-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -114,7 +115,7 @@
 
               <tr>
                 <td>--section-content-wrapper-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -122,7 +123,7 @@
 
               <tr>
                 <td>--section-content-wrapper-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -130,7 +131,7 @@
 
               <tr>
                 <td>--section-content-wrapper-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>var(--content-gap)</td>
                 <td>-</td>
                 <td>-</td>
@@ -138,7 +139,7 @@
 
               <tr>
                 <td>--section-content-wrapper-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>var(--content-padding-top)</td>
                 <td>-</td>
                 <td>-</td>
@@ -146,7 +147,7 @@
 
               <tr>
                 <td>--section-content-wrapper-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--content-padding-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -154,7 +155,7 @@
 
               <tr>
                 <td>--section-content-wrapper-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>var(--content-padding-bottom)</td>
                 <td>-</td>
                 <td>-</td>
@@ -162,7 +163,7 @@
 
               <tr>
                 <td>--section-content-wrapper-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--content-padding-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -170,7 +171,7 @@
 
               <tr>
                 <td>--section-content-wrapper-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>var(--content-max-width)</td>
                 <td>-</td>
                 <td>-</td>
@@ -210,7 +211,7 @@
               <a href="section-content-wrapper-test">Sectie content wrapper test</a> Testpagina met
               de content gegroepeerd binnen <code>section</code>'s met een content wrapper.
             </li>
-            <li><a href="./section">Sectie</a> Content zonder content wrapper.</li>
+            <li><a href="{base}/components/section">Sectie</a> Content zonder content wrapper.</li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/section-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/section-test/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -32,7 +33,7 @@
     <h2>Gebruikte bestanden</h2>
     <p>
       Voor meer informatie over importeren en instellen van componenten. Zie: <a
-        href="../import-styling">Componenten gebruiken en styling toevoegen</a
+        href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a
       >
     </p>
 

--- a/docs/src/routes/(docs)/components/section/+page.svelte
+++ b/docs/src/routes/(docs)/components/section/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -72,7 +73,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -104,7 +105,7 @@
             <tbody>
               <tr>
                 <td>--section-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>var(--content-flex-direction)</td>
                 <td>-</td>
                 <td>-</td>
@@ -112,7 +113,7 @@
 
               <tr>
                 <td>--section-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>var(--content-justify-content)</td>
                 <td>-</td>
                 <td>-</td>
@@ -120,7 +121,7 @@
 
               <tr>
                 <td>--section-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>var(--content-align-items)</td>
                 <td>-</td>
                 <td>-</td>
@@ -128,7 +129,7 @@
 
               <tr>
                 <td>--section-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -136,7 +137,7 @@
 
               <tr>
                 <td>--section-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -144,7 +145,7 @@
 
               <tr>
                 <td>--section-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>var(--page-whitespace-right)</td>
                 <td>-</td>
                 <td>-</td>
@@ -152,7 +153,7 @@
 
               <tr>
                 <td>--section-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -160,7 +161,7 @@
 
               <tr>
                 <td>--section-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>var(--page-whitespace-left)</td>
                 <td>-</td>
                 <td>-</td>
@@ -168,7 +169,7 @@
 
               <tr>
                 <td>--section-max-width</td>
-                <td><a href="../variables#max-width">max-width</a></td>
+                <td><a href="{base}/variables#max-width">max-width</a></td>
                 <td>100%</td>
                 <td>-</td>
                 <td>-</td>
@@ -208,7 +209,7 @@
               <a href="section-test">Sectie test</a> Testpagina met de content gegroepeerd binnen
               <code>section</code>'s.
             </li>
-            <li><a href="./section-content-wrapper">Sectie content wrapper</a></li>
+            <li><a href="{base}/components/section-content-wrapper">Sectie content wrapper</a></li>
           </ul>
         </nav>
       </section>

--- a/docs/src/routes/(docs)/components/side-menu/+page.svelte
+++ b/docs/src/routes/(docs)/components/side-menu/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -176,7 +177,7 @@
             Voeg de referentie naar het Javascript bestand,
             <code>sidemenu.js</code>, toe aan de HTML-pagina's die gebruik dienen te maken van het
             inklapbare zijmenu. Voor meer informatie zie:
-            <a href="../add-js">JavaScript referentie toevoegen</a>.
+            <a href="{base}/add-js">JavaScript referentie toevoegen</a>.
           </li>
         </ol>
 
@@ -208,7 +209,7 @@
                 Voeg een kopie van het variabelenbestand
                 <code>manon/scss/sidemenu/sidemenu-variables</code> toe aan het project. Voor meer
                 informatie zie:
-                <a href="../import-styling#styling-override-variables"
+                <a href="{base}/import-styling#styling-override-variables"
                   >Componenten gebruiken en styling aanpassen - De styling van een een component
                   aanpassen</a
                 >.
@@ -336,7 +337,7 @@
             Voeg de referentie naar het Javascript bestand,
             <code>sidemenu.js</code>, toe aan de HTML-pagina's die gebruik dienen te maken van het
             inklapbare zijmenu. Voor meer informatie zie:
-            <a href="../add-js">JavaScript referentie toevoegen</a>.
+            <a href="{base}/add-js">JavaScript referentie toevoegen</a>.
           </li>
         </ol>
 
@@ -368,7 +369,7 @@
                 Voeg een kopie van het variabelenbestand
                 <code>manon/scss/sidemenu/sidemenu-variables</code> toe aan het project. Voor meer
                 informatie zie:
-                <a href="../import-styling#styling-override-variables"
+                <a href="{base}/import-styling#styling-override-variables"
                   >Componenten gebruiken en styling aanpassen - De styling van een een component
                   aanpassen</a
                 >.

--- a/docs/src/routes/(docs)/components/sidemenu/in-page/+page.svelte
+++ b/docs/src/routes/(docs)/components/sidemenu/in-page/+page.svelte
@@ -32,7 +32,7 @@
 
         <p>In dit voorbeeld staat het zijmenu binnen de pagina bij de content.
           Gebruik deze weergave alleen als de inhoud van het zijmenu specifiek over de content gaat. Bijvoorbeeld een inhoudsopgave.
-          Hoort het zijmenu niet bij de inhoud van de pagina. Plaats het zijmenu dan naast de pagina. Voor meer informatie zie <a href="./next-to-page">Zijmenu naast de pagina</a>.</p>
+          Hoort het zijmenu niet bij de inhoud van de pagina. Plaats het zijmenu dan naast de pagina. Voor meer informatie zie <a href="{base}/components/sidemenu/next-to-page">Zijmenu naast de pagina</a>.</p>
       </section>
 
       <section id="examples">

--- a/docs/src/routes/(docs)/components/sidemenu/next-to-page-collapsible/+page@.svelte
+++ b/docs/src/routes/(docs)/components/sidemenu/next-to-page-collapsible/+page@.svelte
@@ -49,7 +49,7 @@ See: https://kit.svelte.dev/docs/advanced-routing#advanced-layouts-breaking-out-
 
           <p>
             Gaat de inhoud van het zijmenu over de inhoud van de content. En hoort het bij de
-            content. Gebruik dan: <a href="./in-page">Zijmenu binnen de pagina</a>.
+            content. Gebruik dan: <a href="{base}/components/sidemenu/in-page">Zijmenu binnen de pagina</a>.
           </p>
 
           <nav aria-labelledby="table-of-contents">

--- a/docs/src/routes/(docs)/components/sidemenu/next-to-page/+page@.svelte
+++ b/docs/src/routes/(docs)/components/sidemenu/next-to-page/+page@.svelte
@@ -49,7 +49,7 @@ See: https://kit.svelte.dev/docs/advanced-routing#advanced-layouts-breaking-out-
 
           <p>
             Gaat de inhoud van het zijmenu over de inhoud van de content. En hoort het bij de
-            content. Gebruik dan: <a href="./in-page">Zijmenu binnen de pagina</a>
+            content. Gebruik dan: <a href="{base}/components/sidemenu/in-page">Zijmenu binnen de pagina</a>
           </p>
 
           <nav aria-labelledby="table-of-contents">

--- a/docs/src/routes/(docs)/components/spot-large/+page.svelte
+++ b/docs/src/routes/(docs)/components/spot-large/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -115,7 +116,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -130,7 +131,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -156,7 +157,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Import scss-file</h3>
         <Code
@@ -192,295 +193,295 @@
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-1</th>
                 <td>--branding-color-1</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-1</td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-2</th>
                 <td>--branding-color-2</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-2</td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-accent-1</th>
                 <td>--branding-color-accent-1</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-accent-1</td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-accent-2</th>
                 <td>--branding-color-accent-2</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-accent-2</td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-accent-3</th>
                 <td>--branding-color-accent-3</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-accent-3</td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-accent-4</th>
                 <td>--branding-color-accent-4</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-accent-4</td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-4-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <th rowspan="8" scope="rowgroup">branding-color-accent-5</th>
                 <td>--branding-color-accent-5</td>
-                <td><a href="../variables#color-code">color-code</a></td>
+                <td><a href="{base}/variables#color-code">color-code</a></td>
                 <td rowspan="8" scope="rowgroup">branding-color-accent-5</td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-5-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/spot-medium/+page.svelte
+++ b/docs/src/routes/(docs)/components/spot-medium/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -105,7 +106,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -120,7 +121,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -146,7 +147,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -182,37 +183,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -224,37 +225,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -266,37 +267,37 @@
 
               <tr>
                 <td>--branding-color-accent-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -308,37 +309,37 @@
 
               <tr>
                 <td>--branding-color-accent-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -350,37 +351,37 @@
 
               <tr>
                 <td>--branding-color-accent-3-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-3-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/spot-mini/+page.svelte
+++ b/docs/src/routes/(docs)/components/spot-mini/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -95,7 +96,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -110,7 +111,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -136,7 +137,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -172,37 +173,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -214,37 +215,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -256,37 +257,37 @@
 
               <tr>
                 <td>--branding-color-accent-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/spot-small/+page.svelte
+++ b/docs/src/routes/(docs)/components/spot-small/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -44,7 +45,7 @@
                 Door middel van variabelen binnen de CSS of door middel van classes binnen de HTML.
                 Maak gebruik van de CSS-variabelen waar mogelijk en voeg alleen de classes toe in de
                 HTML voor uitzonderingen om de code aanpasbaar en overzichtelijk te houden. Voor
-                meer informatie hierover zie <a href="../use-css-variable"
+                meer informatie hierover zie <a href="{base}/use-css-variable"
                   >CSS-variabelen gebruiken</a
                 >.
               </li>
@@ -100,7 +101,7 @@
 `}
         />
         <p>
-          Voor meer informatie hierover zie <a href="../use-css-variable"
+          Voor meer informatie hierover zie <a href="{base}/use-css-variable"
             >CSS-variabelen gebruiken</a
           >.
         </p>
@@ -115,7 +116,7 @@
         <p>
           De knoppen binnen het "button-base"-bestand maken gebruik van de accentkleur als deze
           binnen het "application-base"-bestand gedefinieerd staat. Voor meer informatie zie <a
-            href="../use-css-variable">CSS-variabelen gebruiken</a
+            href="{base}/use-css-variable">CSS-variabelen gebruiken</a
           >.
         </p>
 
@@ -141,7 +142,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -177,37 +178,37 @@
 
               <tr>
                 <td>--branding-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -219,37 +220,37 @@
 
               <tr>
                 <td>--branding-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -261,37 +262,37 @@
 
               <tr>
                 <td>--branding-color-accent-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-1-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
@@ -303,37 +304,37 @@
 
               <tr>
                 <td>--branding-color-accent-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-active-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
 
               <tr>
                 <td>--branding-color-accent-2-link-visited-hover-text-color</td>
-                <td><a href="../variables#text-color">color</a></td>
+                <td><a href="{base}/variables#text-color">color</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/src/routes/(docs)/components/table-action-buttons/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-action-buttons/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -54,7 +55,7 @@
             Voor tabellen met lange lijsten kan het de gebruiker helpen om gebruik te maken van de
             tabel met sticky header zodat de toelichting van de iconen altijd in beeld blijft. Voor
             meer informatie zie:
-            <a href="./table-sticky-header">tabel met sticky header</a>.
+            <a href="{base}/components/table-sticky-header">tabel met sticky header</a>.
           </li>
         </ul>
       </section>
@@ -221,12 +222,12 @@
             Actieknop icoon
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
               <li>
-                <a href="../variables#justify-content">justify-content</a>
+                <a href="{base}/variables#justify-content">justify-content</a>
               </li>
             </ul>
           </li>
@@ -234,9 +235,9 @@
             Actieknop icoon hover
             <ul>
               <li>
-                <a href="../variables#background-color">background-color</a>
+                <a href="{base}/variables#background-color">background-color</a>
               </li>
-              <li><a href="../variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
             </ul>
           </li>
         </ul>
@@ -244,7 +245,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-action-buttons-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-action-buttons-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-base/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -223,70 +224,70 @@
               <tr>
                 <td rowspan="10" scope="rowgroup">table</td>
                 <td>--table-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--application-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--application-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--application-line-height)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-padding</td>
-                <td><a href="../variables#cell-padding">cell-padding</a></td>
+                <td><a href="{base}/variables#cell-padding">cell-padding</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>var(--application-text-align)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
@@ -294,42 +295,42 @@
               <tr>
                 <td rowspan="6" scope="rowgroup">thead</td>
                 <td>--table-backround-color</td>
-                <td><a href="../variables#backround-color">backround-color</a></td>
+                <td><a href="{base}/variables#backround-color">backround-color</a></td>
                 <td>var(--application-accent-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--application-base-accent-color-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-text-align</td>
-                <td><a href="../variables#text-align">text-align</a></td>
+                <td><a href="{base}/variables#text-align">text-align</a></td>
                 <td>var(--table-text-align)</td>
                 <td>-</td>
               </tr>
@@ -337,42 +338,42 @@
               <tr>
                 <td rowspan="6" scope="rowgroup">th</td>
                 <td>--table-head-cell-cell-padding</td>
-                <td><a href="../variables#cell-padding">cell-padding</a></td>
+                <td><a href="{base}/variables#cell-padding">cell-padding</a></td>
                 <td>var(--table-cells-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-head-cell-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>bolder</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-head-cell-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--table-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-head-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-head-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-head-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
@@ -380,56 +381,56 @@
               <tr>
                 <td rowspan="8" scope="rowgroup">th within tbody</td>
                 <td>--table-body-head-cell-padding</td>
-                <td><a href="../variables#cell-padding">cell-padding</a></td>
+                <td><a href="{base}/variables#cell-padding">cell-padding</a></td>
                 <td>var(--table-cells-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>bolder</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--table-background-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--table-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--table-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-body-head-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
@@ -437,28 +438,28 @@
               <tr>
                 <td rowspan="4" scope="rowgroup">Table row - Zebra striping</td>
                 <td>--table-row-background-color-striping</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>rgba(148, 148, 148, 0.1)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-row-border-width</td>
-                <td><a href="../variables#width">width</a></td>
+                <td><a href="{base}/variables#width">width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-row-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-row-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
@@ -466,42 +467,42 @@
               <tr>
                 <td rowspan="6" scope="rowgroup">Table cell (td)</td>
                 <td>--table-cell-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--table-cells-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--table-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>solid</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>#ccc</td>
                 <td>-</td>
               </tr>
@@ -509,21 +510,21 @@
               <tr>
                 <td rowspan="3" scope="rowgroup">Table cells within the first row</td>
                 <td>--table-first-row-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-cell-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-first-row-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-cell-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-first-row-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-cell-border-color)</td>
                 <td>-</td>
               </tr>
@@ -531,21 +532,21 @@
               <tr>
                 <td rowspan="3" scope="rowgroup">Table cells within the last row</td>
                 <td>--table-last-row-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-cell-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-last-row-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-cell-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-last-row-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-cell-border-color)</td>
                 <td>-</td>
               </tr>
@@ -553,56 +554,56 @@
               <tr>
                 <td rowspan="8" scope="rowgroup">Table footer</td>
                 <td>--table-foot-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>#ddd</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--table-cells-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--table-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--table-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--table-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
@@ -610,56 +611,56 @@
               <tr>
                 <td rowspan="8" scope="rowgroup">Table footer head</td>
                 <td>--table-foot-header-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>transparent</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--table-foot-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--table-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--table-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--table-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-header-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>
@@ -667,56 +668,56 @@
               <tr>
                 <td rowspan="8" scope="rowgroup">Table footer cell styling</td>
                 <td>--table-foot-cell-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>#f0f0f0</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>var(--table-foot-padding)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--table-text-color)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>var(--table-font-weight)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--table-font-size)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>var(--table-border-width)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-border-style</td>
-                <td><a href="../variables#border-style">border-style</a></td>
+                <td><a href="{base}/variables#border-style">border-style</a></td>
                 <td>var(--table-border-style)</td>
                 <td>-</td>
               </tr>
 
               <tr>
                 <td>--table-foot-cell-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--table-border-color)</td>
                 <td>-</td>
               </tr>

--- a/docs/src/routes/(docs)/components/table-caption/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-caption/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -37,7 +38,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>Voeg de <code>caption</code> direct direct binnen de <code>table</code> toe.</li>
           <li>
@@ -136,19 +137,19 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#background-color">background-color</a>
+            <a href="{base}/variables#background-color">background-color</a>
           </li>
-          <li><a href="../variables#text-color">text-color</a></li>
-          <li><a href="../variables#font-size">font-size</a></li>
-          <li><a href="../variables#line-height">line-height</a></li>
-          <li><a href="../variables#padding">padding</a></li>
-          <li><a href="../variables#text-align">text-align</a></li>
+          <li><a href="{base}/variables#text-color">text-color</a></li>
+          <li><a href="{base}/variables#font-size">font-size</a></li>
+          <li><a href="{base}/variables#line-height">line-height</a></li>
+          <li><a href="{base}/variables#padding">padding</a></li>
+          <li><a href="{base}/variables#text-align">text-align</a></li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-caption-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-caption-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-condensed/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-condensed/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -38,7 +39,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>Voeg de class <code>condensed</code> toe op de <code>table</code>.</li>
         </ol>
@@ -138,7 +139,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-condensed-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-condensed-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-expando-row/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-expando-row/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -88,7 +89,7 @@
             Plaats
             <code>&lt;script defer src="pad/naar/expando-rows.min.js"&gt;&lt;/script&gt;</code>
             in de <code>&lt;head&gt;</code> van het document. Voor meer informatie zie:
-            <a href="../add-js">JavaScript toevoegen</a>
+            <a href="{base}/add-js">JavaScript toevoegen</a>
           </li>
           <li>
             Open/sluit-icoon toevoegen:
@@ -294,21 +295,21 @@
                   <tbody>
                     <tr>
                       <td>--expando-rows-table-cell-background-color</td>
-                      <td><a href="../variables#background-color">background-color</a></td>
+                      <td><a href="{base}/variables#background-color">background-color</a></td>
                       <td>#e5e5e5</td>
                       <td>Openklapbare cel - td</td>
                       <td>CSS</td>
                     </tr>
                     <tr>
                       <td>--expando-rows-table-cell-padding</td>
-                      <td><a href="../variables#padding">padding</a></td>
+                      <td><a href="{base}/variables#padding">padding</a></td>
                       <td>2rem 1rem</td>
                       <td>Openklapbare cel - td</td>
                       <td>CSS</td>
                     </tr>
                     <tr>
                       <td>--expando-rows-table-cell-after-breakpoint-padding</td>
-                      <td><a href="../variables#padding">padding</a></td>
+                      <td><a href="{base}/variables#padding">padding</a></td>
                       <td>2rem 3rem</td>
                       <td>Openklapbare cel - td</td>
                       <td>CSS</td>
@@ -316,28 +317,28 @@
 
                     <tr>
                       <td>$breakpoint</td>
-                      <td><a href="../variables#breakpoints">Breekpunt</a></td>
+                      <td><a href="{base}/variables#breakpoints">Breekpunt</a></td>
                       <td>24rem !default</td>
                       <td>Subtitel binnen de openklapbare cel - h2</td>
                       <td>SASS</td>
                     </tr>
                     <tr>
                       <td>--expando-rows-row-background-color</td>
-                      <td><a href="../variables#background-color">background-color</a></td>
+                      <td><a href="{base}/variables#background-color">background-color</a></td>
                       <td>transparent</td>
                       <td>De openklapbare rij</td>
                       <td>CSS</td>
                     </tr>
                     <tr>
                       <td>--expando-rows-row-striping-background-color</td>
-                      <td><a href="../variables#background-color">background-color</a></td>
+                      <td><a href="{base}/variables#background-color">background-color</a></td>
                       <td>var(--table-row-background-color-striping, initial)</td>
                       <td>De openklapbare rij</td>
                       <td>CSS</td>
                     </tr>
                     <tr>
                       <td>--expando-rows-row-font-weight</td>
-                      <td><a href="../variables#font-weight">font-weight</a></td>
+                      <td><a href="{base}/variables#font-weight">font-weight</a></td>
                       <td>bold</td>
                       <td>De openklapbare rij</td>
                       <td>CSS</td>

--- a/docs/src/routes/(docs)/components/table-multiple-columns/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-multiple-columns/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -33,7 +34,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Om een datacel over meerdere kolommen te plaatsen gebruik een
@@ -115,7 +116,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-multiple-columns-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-multiple-columns-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-multiple-rows/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-multiple-rows/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -33,7 +34,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Om een datacel over meerdere rijen te plaatsen gebruik een
@@ -126,7 +127,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-multiple-rows-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-multiple-rows-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-notifications/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-notifications/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -51,7 +52,7 @@
               <li><code>primary</code></li>
             </ul>
             Zie
-            <a href="./notifications">Notifications</a> voor meer informatie.
+            <a href="{base}/components/notifications">Notifications</a> voor meer informatie.
           </li>
         </ul>
       </section>
@@ -157,14 +158,14 @@
           </li>
           <li>
             Bijbehorende melding-type-bestanden. Voor meer informatie en beschikbare types zie:
-            <a href="./notifications">Meldingen</a>
+            <a href="{base}/components/notifications">Meldingen</a>
           </li>
         </ul>
       </section>
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-notifications-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-notifications-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-numerical-data/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-numerical-data/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -36,7 +37,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Om gebruik te maken van de weergave voor numerieke data, voeg de class
@@ -130,7 +131,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-numerical-data-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-numerical-data-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-scope/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-scope/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -132,7 +133,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-scope-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-scope-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-sortable/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-sortable/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -36,7 +37,7 @@
           </li>
           <li>
             Voeg binnen de knop een icoon toe indien gewenst. Voor meer informatie zie:
-            <a href="./button-icon">Icoonknoppen</a>
+            <a href="{base}/components/button-icon">Icoonknoppen</a>
           </li>
           <li>
             Voeg <code>abbr=""</code> toe aan de <code>&lt;th&gt;</code> met een korte duidelijke omschrijving

--- a/docs/src/routes/(docs)/components/table-sticky-header/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-sticky-header/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -56,7 +57,7 @@
               <li><code>explanation</code></li>
               <li><code>primary</code></li>
             </ul>
-            Zie<a href="./notifications">Notifications</a> voor meer informatie.
+            Zie<a href="{base}/components/notifications">Notifications</a> voor meer informatie.
           </li>
         </ul>
       </section>
@@ -208,7 +209,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-sticky-header-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-sticky-header-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table-summary/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-summary/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -36,7 +37,7 @@
             optionele bestanden zie:
             <a href="#requirements">Benodigdheden</a>. Voor meer informatie over importeren en
             instellen van componenten. Zie:
-            <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
           <li>
             Voeg de class <code>summary</code> toe aan de <code>&lt;table&gt;</code> om gebruik te maken
@@ -221,7 +222,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./table-summary-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/table-summary-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/table/+page.svelte
+++ b/docs/src/routes/(docs)/components/table/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Tabel";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Tabel</title>
 </svelte:head>
@@ -23,15 +27,15 @@
           <nav aria-labelledby="types-heading">
             <h3 id="types-heading">Types</h3>
             <ul>
-              <li><a href="./table-base">Basisweergave</a></li>
-              <li><a href="./table-sortable">Sorteerbare tabel</a></li>
+              <li><a href="{base}/components/table-base">Basisweergave</a></li>
+              <li><a href="{base}/components/table-sortable">Sorteerbare tabel</a></li>
               <li>
-                <a href="./table-expando-row">Uitklapbare tabel</a>
+                <a href="{base}/components/table-expando-row">Uitklapbare tabel</a>
               </li>
               <li>
-                <a href="./table-sticky-header">"sticky header"-tabel</a>
+                <a href="{base}/components/table-sticky-header">"sticky header"-tabel</a>
               </li>
-              <li><a href="./table-summary">Samenvattingstabel</a></li>
+              <li><a href="{base}/components/table-summary">Samenvattingstabel</a></li>
             </ul>
           </nav>
 
@@ -39,15 +43,15 @@
             <h3 id="elements-heading">Elementen</h3>
             <ul>
               <li>
-                <a href="./table-action-buttons">Actieknoppen</a>
+                <a href="{base}/components/table-action-buttons">Actieknoppen</a>
               </li>
-              <li><a href="./table-checkbox">Checkboxes</a></li>
-              <li><a href="./table-notifications">Meldingen</a></li>
+              <li><a href="{base}/components/table-checkbox">Checkboxes</a></li>
+              <li><a href="{base}/components/table-notifications">Meldingen</a></li>
               <li>
-                <a href="./table-numerical-data">Numerieke data</a>
+                <a href="{base}/components/table-numerical-data">Numerieke data</a>
               </li>
               <li>
-                <a href="./table-caption">Tabel bijschrift <code>caption</code></a>
+                <a href="{base}/components/table-caption">Tabel bijschrift <code>caption</code></a>
               </li>
             </ul>
           </nav>
@@ -56,14 +60,14 @@
             <h3 id="styling-heading">Opmaak-opties</h3>
             <ul>
               <li>
-                <a href="./table-multiple-rows">Tabeldata over meerdere rijen</a>
+                <a href="{base}/components/table-multiple-rows">Tabeldata over meerdere rijen</a>
               </li>
               <li>
-                <a href="./table-multiple-columns">Tabeldata over meerdere kolommen</a>
+                <a href="{base}/components/table-multiple-columns">Tabeldata over meerdere kolommen</a>
               </li>
-              <li><a href="./table-scope">Tabelrichting</a></li>
+              <li><a href="{base}/components/table-scope">Tabelrichting</a></li>
               <li>
-                <a href="./table-condensed">Gecomprimeerde weergave</a>
+                <a href="{base}/components/table-condensed">Gecomprimeerde weergave</a>
               </li>
             </ul>
           </nav>
@@ -72,7 +76,7 @@
             <h3 id="helper-classes-heading">Helper-classes</h3>
             <ul>
               <li>
-                <a href="../components/nowrap">nowrap</a>
+                <a href="{base}/components/nowrap">nowrap</a>
               </li>
             </ul>
           </nav>

--- a/docs/src/routes/(docs)/components/tabs/+page.svelte
+++ b/docs/src/routes/(docs)/components/tabs/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -101,7 +102,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -177,7 +178,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./tabs-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/tabs-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/tag/+page.svelte
+++ b/docs/src/routes/(docs)/components/tag/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -205,7 +206,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -245,7 +246,7 @@
             <tbody>
               <tr>
                 <td>--tag-font-size</td>
-                <td><a href="../variables#font-size">font-size</a></td>
+                <td><a href="{base}/variables#font-size">font-size</a></td>
                 <td>var(--application-base-font-size)</td>
                 <td>-</td>
                 <td>-</td>
@@ -253,7 +254,7 @@
 
               <tr>
                 <td>--tag-font-weight</td>
-                <td><a href="../variables#font-weight">font-weight</a></td>
+                <td><a href="{base}/variables#font-weight">font-weight</a></td>
                 <td>bold</td>
                 <td>-</td>
                 <td>-</td>
@@ -261,7 +262,7 @@
 
               <tr>
                 <td>--tag-line-height</td>
-                <td><a href="../variables#line-height">line-height</a></td>
+                <td><a href="{base}/variables#line-height">line-height</a></td>
                 <td>var(--application-base-line-height)</td>
                 <td>-</td>
                 <td>-</td>
@@ -269,7 +270,7 @@
 
               <tr>
                 <td>--tag-padding</td>
-                <td><a href="../variables#padding">padding</a></td>
+                <td><a href="{base}/variables#padding">padding</a></td>
                 <td>0.25rem 0.5rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -277,7 +278,7 @@
 
               <tr>
                 <td>--tag-border-radius</td>
-                <td><a href="../variables#border-radius">border-radius</a></td>
+                <td><a href="{base}/variables#border-radius">border-radius</a></td>
                 <td>0.25rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -285,7 +286,7 @@
 
               <tr>
                 <td>--tag-border-width</td>
-                <td><a href="../variables#border-width">border-width</a></td>
+                <td><a href="{base}/variables#border-width">border-width</a></td>
                 <td>1px</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/tags-6-3/+page.svelte
+++ b/docs/src/routes/(docs)/components/tags-6-3/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -496,7 +497,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -542,7 +543,7 @@
             <tbody>
               <tr>
                 <td>--tags-color-1-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-blue-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -550,7 +551,7 @@
 
               <tr>
                 <td>--tags-color-1-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-blue-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -558,7 +559,7 @@
 
               <tr>
                 <td>--tags-color-1-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-blue-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -566,7 +567,7 @@
 
               <tr>
                 <td>--tags-color-1-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-blue-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -574,7 +575,7 @@
 
               <tr>
                 <td>--tags-color-1-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-blue-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -582,7 +583,7 @@
 
               <tr>
                 <td>--tags-color-1-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-blue-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -590,7 +591,7 @@
 
               <tr>
                 <td>--tags-color-1-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-blue-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -598,7 +599,7 @@
 
               <tr>
                 <td>--tags-color-1-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-blue-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -606,7 +607,7 @@
 
               <tr>
                 <td>--tags-color-1-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-blue-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -614,7 +615,7 @@
 
               <tr>
                 <td>--tags-color-2-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-green-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -622,7 +623,7 @@
 
               <tr>
                 <td>--tags-color-2-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-green-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -630,7 +631,7 @@
 
               <tr>
                 <td>--tags-color-2-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-green-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -638,7 +639,7 @@
 
               <tr>
                 <td>--tags-color-2-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-green-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -646,7 +647,7 @@
 
               <tr>
                 <td>--tags-color-2-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-green-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -654,7 +655,7 @@
 
               <tr>
                 <td>--tags-color-2-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-green-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -662,7 +663,7 @@
 
               <tr>
                 <td>--tags-color-2-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-green-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -670,7 +671,7 @@
 
               <tr>
                 <td>--tags-color-2-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-green-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -678,7 +679,7 @@
 
               <tr>
                 <td>--tags-color-2-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-green-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -686,7 +687,7 @@
 
               <tr>
                 <td>--tags-color-3-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-yellow-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -694,7 +695,7 @@
 
               <tr>
                 <td>--tags-color-3-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-yellow-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -702,7 +703,7 @@
 
               <tr>
                 <td>--tags-color-3-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-yellow-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -710,7 +711,7 @@
 
               <tr>
                 <td>--tags-color-3-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-yellow-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -718,7 +719,7 @@
 
               <tr>
                 <td>--tags-color-3-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-yellow-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -726,7 +727,7 @@
 
               <tr>
                 <td>--tags-color-3-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-yellow-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -734,7 +735,7 @@
 
               <tr>
                 <td>--tags-color-3-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-yellow-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -742,7 +743,7 @@
 
               <tr>
                 <td>--tags-color-3-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-yellow-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -750,7 +751,7 @@
 
               <tr>
                 <td>--tags-color-3-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-yellow-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -758,7 +759,7 @@
 
               <tr>
                 <td>--tags-color-4-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-orange-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -766,7 +767,7 @@
 
               <tr>
                 <td>--tags-color-4-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-orange-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -774,7 +775,7 @@
 
               <tr>
                 <td>--tags-color-4-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-orange-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -782,7 +783,7 @@
 
               <tr>
                 <td>--tags-color-4-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-orange-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -790,7 +791,7 @@
 
               <tr>
                 <td>--tags-color-4-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-orange-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -798,7 +799,7 @@
 
               <tr>
                 <td>--tags-color-4-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-orange-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -806,7 +807,7 @@
 
               <tr>
                 <td>--tags-color-4-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-orange-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -814,7 +815,7 @@
 
               <tr>
                 <td>--tags-color-4-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-orange-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -822,7 +823,7 @@
 
               <tr>
                 <td>--tags-color-4-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-orange-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -830,7 +831,7 @@
 
               <tr>
                 <td>--tags-color-5-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-red-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -838,7 +839,7 @@
 
               <tr>
                 <td>--tags-color-5-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-red-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -846,7 +847,7 @@
 
               <tr>
                 <td>--tags-color-5-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-red-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -854,7 +855,7 @@
 
               <tr>
                 <td>--tags-color-5-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-red-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -862,7 +863,7 @@
 
               <tr>
                 <td>--tags-color-5-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-red-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -870,7 +871,7 @@
 
               <tr>
                 <td>--tags-color-5-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-red-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -878,7 +879,7 @@
 
               <tr>
                 <td>--tags-color-5-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-red-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -886,7 +887,7 @@
 
               <tr>
                 <td>--tags-color-5-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-red-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -894,7 +895,7 @@
 
               <tr>
                 <td>--tags-color-5-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-red-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -902,7 +903,7 @@
 
               <tr>
                 <td>--tags-color-6-light-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-violet-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -910,7 +911,7 @@
 
               <tr>
                 <td>--tags-color-6-light-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-violet-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -918,7 +919,7 @@
 
               <tr>
                 <td>--tags-color-6-light-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-violet-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -926,7 +927,7 @@
 
               <tr>
                 <td>--tags-color-6-medium-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-violet-medium-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -934,7 +935,7 @@
 
               <tr>
                 <td>--tags-color-6-medium-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-violet-medium-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -942,7 +943,7 @@
 
               <tr>
                 <td>--tags-color-6-medium-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-violet-medium-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -950,7 +951,7 @@
 
               <tr>
                 <td>--tags-color-6-dark-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-violet-dark-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -958,7 +959,7 @@
 
               <tr>
                 <td>--tags-color-6-dark-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-violet-dark-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -966,7 +967,7 @@
 
               <tr>
                 <td>--tags-color-6-dark-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-violet-dark-border-color)</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/tags-6/+page.svelte
+++ b/docs/src/routes/(docs)/components/tags-6/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -143,7 +144,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <p>
@@ -202,7 +203,7 @@
             <tbody>
               <tr>
                 <td>--tags-color-1-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-blue-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -210,7 +211,7 @@
 
               <tr>
                 <td>--tags-color-1-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-blue-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -218,7 +219,7 @@
 
               <tr>
                 <td>--tags-color-1-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-blue-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -226,7 +227,7 @@
 
               <tr>
                 <td>--tags-color-2-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-green-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -234,7 +235,7 @@
 
               <tr>
                 <td>--tags-color-2-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-green-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -242,7 +243,7 @@
 
               <tr>
                 <td>--tags-color-2-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-green-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -250,7 +251,7 @@
 
               <tr>
                 <td>--tags-color-3-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-yellow-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -258,7 +259,7 @@
 
               <tr>
                 <td>--tags-color-3-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-yellow-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -266,7 +267,7 @@
 
               <tr>
                 <td>--tags-color-3-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-yellow-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -274,7 +275,7 @@
 
               <tr>
                 <td>--tags-color-4-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-orange-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -282,7 +283,7 @@
 
               <tr>
                 <td>--tags-color-4-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-orange-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -290,7 +291,7 @@
 
               <tr>
                 <td>--tags-color-4-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-orange-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -298,7 +299,7 @@
 
               <tr>
                 <td>--tags-color-5-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-red-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -306,7 +307,7 @@
 
               <tr>
                 <td>--tags-color-5-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-red-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -314,7 +315,7 @@
 
               <tr>
                 <td>--tags-color-5-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-red-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -322,7 +323,7 @@
 
               <tr>
                 <td>--tags-color-6-background-color</td>
-                <td><a href="../variables#background-color">background-color</a></td>
+                <td><a href="{base}/variables#background-color">background-color</a></td>
                 <td>var(--tags-soft-violet-light-background-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -330,7 +331,7 @@
 
               <tr>
                 <td>--tags-color-6-text-color</td>
-                <td><a href="../variables#text-color">text-color</a></td>
+                <td><a href="{base}/variables#text-color">text-color</a></td>
                 <td>var(--tags-soft-violet-light-text-color)</td>
                 <td>-</td>
                 <td>-</td>
@@ -338,7 +339,7 @@
 
               <tr>
                 <td>--tags-color-6-border-color</td>
-                <td><a href="../variables#border-color">border-color</a></td>
+                <td><a href="{base}/variables#border-color">border-color</a></td>
                 <td>var(--tags-soft-violet-light-border-color)</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/tags/+page.svelte
+++ b/docs/src/routes/(docs)/components/tags/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -222,7 +223,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -266,7 +267,7 @@
             <tbody>
               <tr>
                 <td>--tags-flex-direction</td>
-                <td><a href="../variables#flex-direction">flex-direction</a></td>
+                <td><a href="{base}/variables#flex-direction">flex-direction</a></td>
                 <td>row</td>
                 <td>-</td>
                 <td>-</td>
@@ -274,7 +275,7 @@
 
               <tr>
                 <td>--tags-align-items</td>
-                <td><a href="../variables#align-items">align-items</a></td>
+                <td><a href="{base}/variables#align-items">align-items</a></td>
                 <td>center</td>
                 <td>-</td>
                 <td>-</td>
@@ -282,7 +283,7 @@
 
               <tr>
                 <td>--tags-justify-content</td>
-                <td><a href="../variables#justify-content">justify-content</a></td>
+                <td><a href="{base}/variables#justify-content">justify-content</a></td>
                 <td>left</td>
                 <td>-</td>
                 <td>-</td>
@@ -290,7 +291,7 @@
 
               <tr>
                 <td>--tags-flex-wrap</td>
-                <td><a href="../variables#flex-wrap">flex-wrap</a></td>
+                <td><a href="{base}/variables#flex-wrap">flex-wrap</a></td>
                 <td>wrap</td>
                 <td>-</td>
                 <td>-</td>
@@ -298,7 +299,7 @@
 
               <tr>
                 <td>--tags-gap</td>
-                <td><a href="../variables#gap">gap</a></td>
+                <td><a href="{base}/variables#gap">gap</a></td>
                 <td>0.5rem</td>
                 <td>-</td>
                 <td>-</td>
@@ -306,7 +307,7 @@
 
               <tr>
                 <td>--tags-padding-top</td>
-                <td><a href="../variables#padding-top">padding-top</a></td>
+                <td><a href="{base}/variables#padding-top">padding-top</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -314,7 +315,7 @@
 
               <tr>
                 <td>--tags-padding-right</td>
-                <td><a href="../variables#padding-right">padding-right</a></td>
+                <td><a href="{base}/variables#padding-right">padding-right</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -322,7 +323,7 @@
 
               <tr>
                 <td>--tags-padding-bottom</td>
-                <td><a href="../variables#padding-bottom">padding-bottom</a></td>
+                <td><a href="{base}/variables#padding-bottom">padding-bottom</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -330,7 +331,7 @@
 
               <tr>
                 <td>--tags-padding-left</td>
-                <td><a href="../variables#padding-left">padding-left</a></td>
+                <td><a href="{base}/variables#padding-left">padding-left</a></td>
                 <td>0</td>
                 <td>-</td>
                 <td>-</td>
@@ -338,7 +339,7 @@
 
               <tr>
                 <td>--tags-list-style</td>
-                <td><a href="../variables#list-style">list-style</a></td>
+                <td><a href="{base}/variables#list-style">list-style</a></td>
                 <td>none</td>
                 <td>-</td>
                 <td>-</td>

--- a/docs/src/routes/(docs)/components/tile-cover-image/+page.svelte
+++ b/docs/src/routes/(docs)/components/tile-cover-image/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -29,14 +30,14 @@
           <li>
             Voeg <code>class="tile"</code> toe voor de Tegelweergave met cover-afbeelding op een
             enkel element. Voor meer informatie zie:
-            <a href="./tiles">tegelweergave</a>
+            <a href="{base}/components/tiles">tegelweergave</a>
           </li>
           <li>
             Voeg de class <code>image-cover</code> toe voor de correcte weergave. Voor meer
             informatie zie: <a href="#tile-image-cover">tegel met cover-afbeelding</a> of
             <a href="#tiles-image-cover">groep met tegels met cover-afbeelding</a>. Voor meer
             informatie over cover-afbeelding zie
-            <a href="./image-cover">cover-afbeelding</a>
+            <a href="{base}/components/image-cover">cover-afbeelding</a>
           </li>
         </ul>
       </section>
@@ -155,7 +156,7 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#object-position">object-position</a>
+            <a href="{base}/variables#object-position">object-position</a>
           </li>
         </ul>
       </section>
@@ -164,7 +165,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>

--- a/docs/src/routes/(docs)/components/tile-groups/+page.svelte
+++ b/docs/src/routes/(docs)/components/tile-groups/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -30,7 +31,7 @@
           <li>
             Voeg <code>class="tile"</code> toe voor de Gegroepeerde content binnen tegels op een
             enkel element. Voor meer informatie zie:
-            <a href="./tiles">tegelweergave</a>
+            <a href="{base}/components/tiles">tegelweergave</a>
           </li>
           <li>
             Voeg de benodigde bestanden toe aan het project. Voor een overzicht van de benodigde en
@@ -77,20 +78,20 @@
         <h2>Instelbare variabelen</h2>
         <ul>
           <li>
-            <a href="../variables#flex-direction">flex-direction</a>
+            <a href="{base}/variables#flex-direction">flex-direction</a>
           </li>
-          <li><a href="../variables#gap">gap</a></li>
-          <li><a href="../variables#border-width">border-width</a></li>
-          <li><a href="../variables#border-style">border-style</a></li>
-          <li><a href="../variables#border-color">border-color</a></li>
-          <li><a href="../variables#padding-top">padding-top</a></li>
+          <li><a href="{base}/variables#gap">gap</a></li>
+          <li><a href="{base}/variables#border-width">border-width</a></li>
+          <li><a href="{base}/variables#border-style">border-style</a></li>
+          <li><a href="{base}/variables#border-color">border-color</a></li>
+          <li><a href="{base}/variables#padding-top">padding-top</a></li>
           <li>
-            <a href="../variables#padding-right">padding-right</a>
+            <a href="{base}/variables#padding-right">padding-right</a>
           </li>
           <li>
-            <a href="../variables#padding-bottom">padding-bottom</a>
+            <a href="{base}/variables#padding-bottom">padding-bottom</a>
           </li>
-          <li><a href="../variables#padding-left">padding-left</a></li>
+          <li><a href="{base}/variables#padding-left">padding-left</a></li>
         </ul>
       </section>
 
@@ -98,7 +99,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -115,7 +116,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./tile-groups-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/tile-groups-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/components/tiles/+page.svelte
+++ b/docs/src/routes/(docs)/components/tiles/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
 </script>
@@ -41,10 +42,10 @@
             </li>
             <li><a href="#tiles">Groep met tegels</a></li>
             <li>
-              <a href="./tile-cover-image">Tegel met cover-afbeelding</a>
+              <a href="{base}/components/tile-cover-image">Tegel met cover-afbeelding</a>
             </li>
             <li>
-              <a href="./tile-groups">Gegroepeerde content binnen tegels</a>
+              <a href="{base}/components/tile-groups">Gegroepeerde content binnen tegels</a>
             </li>
           </ul>
         </nav>
@@ -161,33 +162,33 @@
             Tegel
             <ul>
               <li>
-                <a href="../variables#border-width">border-width</a>
+                <a href="{base}/variables#border-width">border-width</a>
               </li>
               <li>
-                <a href="../variables#border-style">border-style</a>
+                <a href="{base}/variables#border-style">border-style</a>
               </li>
               <li>
-                <a href="../variables#border-color">border-color</a>
+                <a href="{base}/variables#border-color">border-color</a>
               </li>
               <li>
-                <a href="../variables#flex-direction">flex-direction</a>
+                <a href="{base}/variables#flex-direction">flex-direction</a>
               </li>
-              <li><a href="../variables#gap">gap</a></li>
-              <li><a href="../variables#padding">padding</a></li>
+              <li><a href="{base}/variables#gap">gap</a></li>
+              <li><a href="{base}/variables#padding">padding</a></li>
             </ul>
           </li>
           <li>
             Titel
             <ul>
-              <li><a href="../variables#text-color">text-color</a></li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
             </ul>
           </li>
           <li>
             Subtitel
             <ul>
-              <li><a href="../variables#text-color">text-color</a></li>
-              <li><a href="../variables#font-size">font-size</a></li>
+              <li><a href="{base}/variables#text-color">text-color</a></li>
+              <li><a href="{base}/variables#font-size">font-size</a></li>
             </ul>
           </li>
         </ul>
@@ -197,7 +198,7 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="../import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
         </p>
         <h3>Benodigd</h3>
         <ul>
@@ -212,7 +213,7 @@
 
       <section id="related">
         <h2>Gerelateerde pagina's</h2>
-        <a href="./tiles-test">Test- en voorbeelden-pagina</a>
+        <a href="{base}/components/tiles-test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/(docs)/documentation/+page.svelte
+++ b/docs/src/routes/(docs)/documentation/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Documentatie";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Documentatie</title>
 </svelte:head>
@@ -27,11 +31,11 @@
           <li>
             <a href="#manon-quick-start">Manon gebruiken binnen een project</a>
           </li>
-          <li><a href="./add-fonts">Lettertype toevoegen</a></li>
-          <li><a href="./add-js">JavaScript toevoegen</a></li>
-          <li><a href="./variables">Variabelen</a></li>
+          <li><a href="{base}/add-fonts">Lettertype toevoegen</a></li>
+          <li><a href="{base}/add-js">JavaScript toevoegen</a></li>
+          <li><a href="{base}/variables">Variabelen</a></li>
           <li>
-            <a href="./import-styling">Componenten gebruiken en styling toevoegen</a>
+            <a href="{base}/import-styling">Componenten gebruiken en styling toevoegen</a>
           </li>
         </ul>
       </nav>

--- a/docs/src/routes/(docs)/import-styling/+page.svelte
+++ b/docs/src/routes/(docs)/import-styling/+page.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+  import { base } from "$app/paths";
   import Code from "$lib/Code.svelte";
 </script>
 
@@ -90,7 +91,7 @@
           Vul het gekopieerde variabelenbestand in met de gewenste stijlkeuzes om de styling van een
           component te overschrijven via de beschikbare variabelen. Voor informatie over het
           aanpassen en overschrijven van variabelen zie
-          <a href="./variables">variabelen</a>
+          <a href="{base}/variables">variabelen</a>
         </li>
         <li>
           Voeg de referentie naar het nieuwe bestand toe aan het

--- a/docs/src/routes/(docs)/variables/+page.svelte
+++ b/docs/src/routes/(docs)/variables/+page.svelte
@@ -2,6 +2,10 @@
   export const breadcrumb = "Variabelen";
 </script>
 
+<script>
+  import { base } from "$app/paths";
+</script>
+
 <svelte:head>
   <title>Variabelen</title>
 </svelte:head>
@@ -439,7 +443,7 @@
                 <code>sans-serif</code>, <code>serif</code>, of een lettertype dat beschikbaar is
                 binnen het project <code>"Manon icons"</code>. Voor het toevoegen van lettertypes
                 aan het project zie:
-                <a href="./add-fonts">Lettertype toevoegen</a>.
+                <a href="{base}/add-fonts">Lettertype toevoegen</a>.
               </td>
             </tr>
 

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -15,9 +15,9 @@ const config = {
       $img: "src/img",
     },
     paths: {
-      base: process.argv.includes('dev') ? '' : process.env.BASE_PATH,
-      relative: true
-    }
+      base: process.argv.includes("dev") ? "" : process.env.BASE_PATH || "",
+      relative: true,
+    },
   },
   preprocess: [vitePreprocess(), importAssets()],
   onwarn: (warning, handler) => {


### PR DESCRIPTION
This PR changes all docs links to use hrefs relative to `{base}`.

This avoids issues with relative paths behaving differently depending on whether the current page's URL in the browser has a `/` at the end or not. E.g. if the current URL is `/components`, `href="./components/icon"` works, but it the current URL is `/components/`, the current page could work fine but the link would point to `/components/components/icons`.