### PR TITLE
chore(add-npm-tag): add npm tags to releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,13 +23,18 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
-      - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - run: |
+          RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          NPM_TAG=$(echo ${RELEASE_VERSION} | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          echo "NPM_TAG=${NPM_TAG:-latest}" >> $GITHUB_ENV
+
       - name: Publish
         # pnpm checks whether you are on the main branch when running publish,
         # but github will checkout the tag, so we need to disable the check
         run: |
           pnpm --recursive npm-version --no-git-tag-version ${{ env.RELEASE_VERSION }}
-          pnpm --recursive publish --no-git-checks --access public
+          pnpm --recursive publish --no-git-checks --access public --tag ${{ env.NPM_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -50,12 +55,17 @@ jobs:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'
 
-      - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - run: |
+          RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          NPM_TAG=$(echo ${RELEASE_VERSION} | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          echo "NPM_TAG=${NPM_TAG:-latest}" >> $GITHUB_ENV
+
       - name: Publish
         # pnpm checks whether you are on the main branch when running publish,
         # but github will checkout the tag, so we need to disable the check
         run: |
           pnpm --recursive npm-version --no-git-tag-version ${{ env.RELEASE_VERSION }}
-          pnpm --recursive publish --no-git-checks --access public
+          pnpm --recursive publish --no-git-checks --access public --tag ${{ env.NPM_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Based on the github tag the npm tag is added.

For example if we release [v16.3.0-beta.2](https://github.com/minvws/nl-rdo-manon/releases/tag/v16.3.0-beta.2) the npm tag `beta` is set.

If we release [v16.2.0](https://github.com/minvws/nl-rdo-manon/releases/tag/v16.2.0) the npm tag `latest` is set.