### PR TITLE
fix: laravel-mix example

### DIFF
--- a/examples/laravel-mix/main.scss
+++ b/examples/laravel-mix/main.scss
@@ -7,5 +7,5 @@
 
 // Load a theme
 @use "@minvws/manon-themes/basic-bold" with (
-  $manon-font-path: "~@minvws/manon-themes/basic-bold/fonts"
+  $font-path: "~@minvws/manon-themes/basic-bold/fonts"
 );


### PR DESCRIPTION
Fix the `$font-path` variable name in the theme import in the laravel-mix example.
