### PR TITLE
chore: fix syntax for gfm highlight in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Manon
 
-> [INFO]
+> [!NOTE]
 > For English, see [English](#english)
 
 De documentatie is te vinden op https://minvws.github.io/nl-rdo-manon. Deze wordt gegenereerd op basis van de [docs](./docs) directory binnen deze repo.


### PR DESCRIPTION
Fix the highlight syntax for the "For English, see [English]" note in the
readme.
