### PR TITLE
fix: npm publish registry-url

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,13 +1,20 @@
 name: Setup
-description: 'Setup Node.js and pnpm and install dependencies'
+description: "Setup Node.js and pnpm and install dependencies"
+
+inputs:
+  registry-url:
+    required: false
+    description: "Registry URL to setup up for auth. Passed on to actions/setup-node."
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: ".nvmrc"
+        registry-url: ${{ inputs.registry-url }}
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+        with:
+          registry-url: "https://registry.npmjs.org"
       - name: Get semver from tag
         run: |
           RELEASE_VERSION=${GITHUB_REF#refs/*/}
@@ -32,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+        with:
+          registry-url: "https://npm.pkg.github.com"
       - name: Get semver from tag
         run: |
           RELEASE_VERSION=${GITHUB_REF#refs/*/}


### PR DESCRIPTION
Fix the CI regression from #511, which inadvertantly removed the `registry-url` from the publish jobs.
