### PR TITLE
fix(manon): increase border contrast on input fields with notifications

### DIFF
--- a/manon/colors/notification-colors.scss
+++ b/manon/colors/notification-colors.scss
@@ -8,21 +8,21 @@
 
   --error-background-color: #ffd9d9;
   --error-text-color: #000;
-  --error-border-color: #d98383;
+  --error-border-color: #b25451;
 
   --explanation-background-color: #d9edff;
   --explanation-text-color: #000;
-  --explanation-border-color: #a6c1d8;
+  --explanation-border-color: #537399;
 
   --warning-background-color: #fff2d1;
   --warning-text-color: #000;
-  --warning-border-color: #f6cb5f;
+  --warning-border-color: #aa5d0c;
 
   --confirmation-background-color: #deffdb;
   --confirmation-text-color: #000;
-  --confirmation-border-color: #9ac596;
+  --confirmation-border-color: #627660;
 
-  --system-background-color: #eee;
+  --system-background-color: var(--grey-2);
   --system-text-color: #000;
-  --system-border-color: #c7c7c7;
+  --system-border-color: #6d6d6d;
 }

--- a/themes/basic-bold/components/notification.scss
+++ b/themes/basic-bold/components/notification.scss
@@ -1,0 +1,9 @@
+/* Notification styling */
+
+:root {
+    --notification-error-border-color: transparent;
+    --notification-confirmation-border-color: transparent;
+    --notification-explanation-border-color: transparent;
+    --notification-warning-border-color: transparent;
+    --notification-system-border-color: transparent;
+ }

--- a/themes/basic-bold/theme.scss
+++ b/themes/basic-bold/theme.scss
@@ -24,18 +24,20 @@
 /* Components */
 @use "components/accordion";
 @use "components/breadcrumb-bar";
+@use "components/button-base";
+@use "components/button-cta";
 @use "components/filter";
+@use "components/footer-navigation-link";
+@use "components/footer";
+@use "components/form-input";
 @use "components/icon";
 @use "components/logo";
 @use "components/pagination";
 @use "components/sidemenu";
-@use "components/tile";
-@use "components/button-base";
-@use "components/button-cta";
-@use "components/form-input";
-@use "components/footer";
-@use "components/footer-navigation-link";
 @use "components/skip-to-content";
+@use "components/tile";
+@use "components/notification";
+
 
 /* Header */
 @use "components/header";

--- a/themes/soft/components/notification.scss
+++ b/themes/soft/components/notification.scss
@@ -1,0 +1,9 @@
+/* Notification styling */
+
+:root {
+    --notification-error-border-color: transparent;
+    --notification-confirmation-border-color: transparent;
+    --notification-explanation-border-color: transparent;
+    --notification-warning-border-color: transparent;
+    --notification-system-border-color: transparent;
+ }

--- a/themes/soft/theme.scss
+++ b/themes/soft/theme.scss
@@ -23,3 +23,4 @@
 @use "components/tile";
 @use "components/header-navigation";
 @use "components/logo";
+@use "components/notification";


### PR DESCRIPTION
Updates input border color with increased contrast in themes soft and basic-bold.

Solves:  https://github.com/minvws/nl-rdo-manon/issues/432