### PR TITLE
docs: table checkbox accessibility

### DIFF
--- a/docs/src/routes/(docs)/components/table-checkbox-test/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-checkbox-test/+page.svelte
@@ -25,24 +25,41 @@
         <div class="horizontal-scroll">
           <form>
             <table>
-              <caption> Tabelvoorbeeld met selectievak: </caption>
+              <caption>
+                Tabelvoorbeeld met selectievak:
+                <span class="visually-hidden">
+                  Selectievak in kolom 1 rij 1 selecteert alle rijen.
+                </span>
+              </caption>
               <thead>
                 <tr>
-                  <th scope="col"><input type="checkbox" /></th>
-                  <th scope="col">Table header heading</th>
-                  <th scope="col">Action</th>
+                  <th scope="col">
+                    <span class="visually-hidden">Selectie</span>
+                    <input type="checkbox" />
+                  </th>
+                  <th scope="col">Naam</th>
+                  <th scope="col">Actie</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td><input type="checkbox" /></td>
-                  <td>Ipsum</td>
-                  <td>
-                    <form><input type="submit" value="Lorem" /></form>
-                  </td>
+                  <td><input type="checkbox" id="lorem-input-1" /></td>
+                  <td><label for="lorem-input-1">Lorem</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
+                </tr>
+                <tr>
+                  <td><input type="checkbox" id="ipsum-input-1" /></td>
+                  <td><label for="ipsum-input-1">Ipsum</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
+                </tr>
+                <tr>
+                  <td><input type="checkbox" id="dolor-input-1" /></td>
+                  <td><label for="dolor-input-1">Dolor</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
                 </tr>
               </tbody>
             </table>
+            <button type="submit">Actie uitvoeren op geselecteerde items</button>
           </form>
         </div>
 
@@ -52,23 +69,44 @@
           code={`
 <div class="horizontal-scroll">
   <form>
-    <table>
-      <caption>Tabelvoorbeeld met selectievak:</caption>
-      <thead>
-        <tr>
-          <th scope="col"><input type="checkbox"></th>
-          <th scope="col">Table header heading</th>
-          <th scope="col">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><input type="checkbox"></td>
-          <td>Ipsum</td>
-          <td><form><input type="submit" value="Lorem"></form></td>
-        </tr>
-      </tbody>
-    </table>
+    <form>
+      <table>
+        <caption>
+          Tabelvoorbeeld met selectievak:
+          <span class="visually-hidden">
+            Selectievak in kolom 1 rij 1 selecteert alle rijen.
+          </span>
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">
+              <span class="visually-hidden">Selectie</span>
+              <input type="checkbox" />
+            </th>
+            <th scope="col">Naam</th>
+            <th scope="col">Actie</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><input type="checkbox" id="lorem-input-1"/></td>
+            <td><label for="lorem-input-1">Lorem</label></td>
+            <td><button type="button">Actie uitvoeren</button></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox" id="ipsum-input-1"/></td>
+            <td><label for="ipsum-input-1">Ipsum</label></td>
+            <td><button type="button">Actie uitvoeren</button></td>
+          </tr>
+          <tr>
+            <td><input type="checkbox" id="dolor-input-1"/></td>
+            <td><label for="dolor-input-1">Dolor</label></td>
+            <td><button type="button">Actie uitvoeren</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <button type="submit">Actie uitvoeren op geselecteerde items</button>
+    </form>
   </form>
 </div>
 `}
@@ -78,28 +116,41 @@
         <h4>Visueel voorbeeld:</h4>
         <div class="horizontal-scroll">
           <table>
-            <caption> Tabelvoorbeeld met selectievak: </caption>
+            <caption>
+              Tabelvoorbeeld met selectievak:
+              <span class="visually-hidden">
+                Selectievak in kolom 1 rij 1 selecteert alle rijen.
+              </span>
+            </caption>
             <thead>
               <tr>
                 <th scope="col">
+                  <span class="visually-hidden">Selectie</span>
                   <form><input type="checkbox" /></form>
                 </th>
-                <th scope="col">Table header heading</th>
-                <th scope="col">Action</th>
+                <th scope="col">Naam</th>
+                <th scope="col">Actie</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>
-                  <form><input type="checkbox" /></form>
-                </td>
-                <td>Ipsum</td>
-                <td>
-                  <form><input type="submit" value="Lorem" /></form>
-                </td>
+                <td><form><input type="checkbox" id="lorem-input-2" /></form></td>
+                <td><label for="lorem-input-2">Lorem</label></td>
+                <td><button type="button">Actie uitvoeren</button></td>
+              </tr>
+              <tr>
+                <td><form><input type="checkbox" id="ipsum-input-2" /></form></td>
+                <td><label for="ipsum-input-2">Ipsum</label></td>
+                <td><button type="button">Actie uitvoeren</button></td>
+              </tr>
+              <tr>
+                <td><form><input type="checkbox" id="dolor-input-2" /></form></td>
+                <td><label for="dolor-input-2">Dolor</label></td>
+                <td><button type="button">Actie uitvoeren</button></td>
               </tr>
             </tbody>
           </table>
+          <button type="submit">Actie uitvoeren op geselecteerde items</button>
         </div>
 
         <h4>HTML-voorbeeld:</h4>
@@ -108,22 +159,41 @@
           code={`
 <div class="horizontal-scroll">
   <table>
-    <caption>Tabelvoorbeeld met selectievak:</caption>
+    <caption>
+      Tabelvoorbeeld met selectievak:
+      <span class="visually-hidden">
+        Selectievak in kolom 1 rij 1 selecteert alle rijen.
+      </span>
+    </caption>
     <thead>
       <tr>
-        <th scope="col"><form><input type="checkbox"></form></th>
-        <th scope="col">Table header heading</th>
-        <th scope="col">Action</th>
+        <th scope="col">
+          <span class="visually-hidden">Selectie</span>
+          <form><input type="checkbox" /></form>
+        </th>
+        <th scope="col">Naam</th>
+        <th scope="col">Actie</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><form><input type="checkbox"></form></td>
-        <td>Ipsum</td>
-        <td><form><input type="submit" value="Lorem"></form></td>
+        <td><form><input type="checkbox" id="lorem-input-2" /></form></td>
+        <td><label for="lorem-input-2">Lorem</label></td>
+        <td><button type="button">Actie uitvoeren</button></td>
+      </tr>
+      <tr>
+        <td><form><input type="checkbox" id="ipsum-input-2" /></form></td>
+        <td><label for="ipsum-input-2">Ipsum</label></td>
+        <td><button type="button">Actie uitvoeren</button></td>
+      </tr>
+      <tr>
+        <td><form><input type="checkbox" id="dolor-input-2" /></form></td>
+        <td><label for="dolor-input-2">Dolor</label></td>
+        <td><button type="button">Actie uitvoeren</button></td>
       </tr>
     </tbody>
   </table>
+  <button type="submit">Actie uitvoeren op geselecteerde items</button>
 </div>
 `}
         />

--- a/docs/src/routes/(docs)/components/table-checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-checkbox/+page.svelte
@@ -43,6 +43,11 @@
             Zorg dat de checkbox een toegankelijk label heeft dat de rij uniek identificeert.
             <ul>
               <li>
+                Staat de checkbox in een cel met tekst? Gebruik dan bij voorkeur die tekst als
+                label. Identificeert de tekst de rij niet (voldoende)? Overweeg dan of de plaatsing
+                van de checkbox wel duidelijk genoeg is.
+              </li>
+              <li>
                 Gebruik als label bijvoorbeeld een naam, ID of andere unieke informatie uit de
                 tabelrij. Zorg dat het label geen informatie bevat die niet ook visueel aanwezig is.
               </li>
@@ -54,6 +59,12 @@
                 met het <code>id</code> van de checkbox.
               </li>
             </ul>
+          </li>
+          <li>
+            Staan de checkboxes in een eigen kolom zonder header-tekst? Voeg dan een visueel
+            verborgen tekst toe aan de header. Bijvoorbeeld: <code
+              >{`<th><span class="visually-hidden">Selectie</span></th>`}</code
+            >.
           </li>
         </ol>
 

--- a/docs/src/routes/(docs)/components/table-checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-checkbox/+page.svelte
@@ -5,6 +5,13 @@
 <script>
   import Code from "$lib/Code.svelte";
   import SideMenu from "$lib/SideMenu.svelte";
+  let lorem = false;
+  let ipsum = false;
+  let dolor = false;
+  $: allSelected = lorem && ipsum && dolor;
+  const toggleAll = () => {
+    lorem = ipsum = dolor = !(lorem && ipsum && dolor);
+  };
 </script>
 
 <svelte:head>
@@ -30,17 +37,56 @@
         <ol>
           <li>
             Voeg de <code>checkbox</code> toe aan de benodigde cellen. Voor het voorbeeld zie:
-            <a href="#examples">Voorbeelden</a>
+            <a href="#examples">Voorbeelden</a>.
+          </li>
+          <li>
+            Zorg dat de checkbox een toegankelijk label heeft dat de rij uniek identificeert.
+            <ul>
+              <li>
+                Gebruik als label bijvoorbeeld een naam, ID of andere unieke informatie uit de
+                tabelrij. Zorg dat het label geen informatie bevat die niet ook visueel aanwezig is.
+              </li>
+              <li>
+                Het toevoegen van een toegankelijk label kan bijvoorbeeld met <code>aria-label</code
+                >, of door de tekst van een andere cel in een <code>{`<label>`}</code> te plaatsen.
+                Geef in dat geval de checkbox een <code>id</code> en geef het label een
+                <code>for</code>
+                met het <code>id</code> van de checkbox.
+              </li>
+            </ul>
           </li>
         </ol>
 
         <h2>Aandachtspunten</h2>
         <ul>
           <li>
-            Een <code>checkbox</code> binnen een tabel header cell <code>th</code> wordt vaak gebruikt
-            om alle checkboxes binnen de tabel aan/uit te zetten.
+            Zorg ervoor dat het duidelijk is wat er gebeurt als een checkbox geselecteerd wordt.
           </li>
-          <li>Dit element bevat momenteel geen JavaScript of logica voorbeeld.</li>
+          <li>
+            Het is mogelijk een <code>checkbox</code> toe te voegen binnen de <code>{`<th>`}</code>
+            waarmee alle checkboxes tegelijkertijd kunnen worden aan- of uit-geschakelt.
+            <ul>
+              <li>
+                Om verwarring te voorkomen, kan deze checkbox beter <strong>geen</strong> toegankelijk
+                label krijgen, omdat deze anders door de meeste screenreaders voor elke rij voorgelezen
+                zou worden.
+              </li>
+              <li>
+                In plaats daarvan is het belangrijk om in de <code>{`<caption>`}</code> de functie
+                van de checkbox in de header toe te lichten. Maak deze toelichting bij voorkeur zo
+                kort en duidelijk mogelijk. Bijvoorbeeld: "selectievak in kolom 1 rij 1 selecteert
+                alle rijen". Plaats de toelichting eventueel in een
+                <code>{`<span class="visually-hidden">`}</code> als het wenselijk is om deze visueel
+                te verbergen.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong
+              >Het is voor dit component nodig om het dynamische gedrag zelf via JavaScript te
+              implementeren.</strong
+            > De exacte implementatie in JavaScript is afhankelijk van de context.
+          </li>
         </ul>
       </section>
 
@@ -50,24 +96,41 @@
         <div class="horizontal-scroll">
           <form>
             <table>
-              <caption> Tabelvoorbeeld met selectievak: </caption>
+              <caption>
+                Tabelvoorbeeld met selectievak:
+                <span class="visually-hidden">
+                  Selectievak in kolom 1 rij 1 selecteert alle rijen.
+                </span>
+              </caption>
               <thead>
                 <tr>
-                  <th scope="col"><input type="checkbox" /></th>
-                  <th scope="col">Table header heading</th>
-                  <th scope="col">Action</th>
+                  <th scope="col">
+                    <span class="visually-hidden">Selectie</span>
+                    <input type="checkbox" bind:checked={allSelected} on:change={toggleAll} />
+                  </th>
+                  <th scope="col">Naam</th>
+                  <th scope="col">Actie</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td><input type="checkbox" /></td>
-                  <td>Ipsum</td>
-                  <td>
-                    <form><input type="submit" value="Lorem" /></form>
-                  </td>
+                  <td><input type="checkbox" id="lorem-input" bind:checked={lorem} /></td>
+                  <td><label for="lorem-input">Lorem</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
+                </tr>
+                <tr>
+                  <td><input type="checkbox" id="ipsum-input" bind:checked={ipsum} /></td>
+                  <td><label for="ipsum-input">Ipsum</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
+                </tr>
+                <tr>
+                  <td><input type="checkbox" id="dolor-input" bind:checked={dolor} /></td>
+                  <td><label for="dolor-input">Dolor</label></td>
+                  <td><button type="button">Actie uitvoeren</button></td>
                 </tr>
               </tbody>
             </table>
+            <button type="submit">Actie uitvoeren op geselecteerde items</button>
           </form>
         </div>
 
@@ -75,27 +138,48 @@
         <Code
           language="html"
           code={`
+
 <div class="horizontal-scroll">
   <form>
     <table>
-      <caption>Tabelvoorbeeld met selectievak:</caption>
+      <caption>
+        Tabelvoorbeeld met selectievak:
+        <span class="visually-hidden">
+          Selectievak in kolom 1 rij 1 selecteert alle rijen.
+        </span>
+      </caption>
       <thead>
         <tr>
-          <th scope="col"><input type="checkbox"></th>
-          <th scope="col">Table header heading</th>
-          <th scope="col">Action</th>
+          <th scope="col">
+            <span class="visually-hidden">Selectie</span>
+            <input type="checkbox" onchange="toggleAll()" />
+          </th>
+          <th scope="col">Naam</th>
+          <th scope="col">Actie</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td><input type="checkbox"></td>
-          <td>Ipsum</td>
-          <td><form><input type="submit" value="Lorem"></form></td>
+          <td><input type="checkbox" id="lorem-input" /></td>
+          <td><label for="lorem-input">Lorem</label></td>
+          <td><button type="button">Actie uitvoeren</button></td>
+        </tr>
+        <tr>
+          <td><input type="checkbox" id="ipsum-input" /></td>
+          <td><label for="ipsum-input">Ipsum</label></td>
+          <td><button type="button">Actie uitvoeren</button></td>
+        </tr>
+        <tr>
+          <td><input type="checkbox" id="dolor-input" /></td>
+          <td><label for="dolor-input">Dolor</label></td>
+          <td><button type="button">Actie uitvoeren</button></td>
         </tr>
       </tbody>
     </table>
+    <button type="submit">Actie uitvoeren op geselecteerde items</button>
   </form>
 </div>
+
 `}
         />
       </section>


### PR DESCRIPTION
This PR updates the docs regarding checkboxes in tables to ensure WCAG SC 1.3.1 and 4.1.2 are met and adds a (very) simple JS example implementation for the "select all" behaviour.

Screenreader demo (NVDA 2024.1, FireFox 125.0.3):

<img src="https://github.com/minvws/nl-rdo-manon/assets/67802/e3da5547-2034-46ef-931c-bdbd86ab38fb" alt="Screenshot" width="655"/>

Closes #416
