### PR TITLE
ci: fix github pages docs redirects (apply BASE_PATH)

### DIFF
--- a/docs/src/routes/+layout.js
+++ b/docs/src/routes/+layout.js
@@ -1,12 +1,16 @@
 import { redirect } from "@sveltejs/kit";
 import { redirects } from "../redirects.js";
+import { base } from "$app/paths";
 
 export const prerender = true;
 
 /** @type {import('./$types').LayoutLoad} */
 export function load({ url }) {
-  const { pathname } = url;
+  let { pathname } = url;
+  if (base && pathname.startsWith(base)) {
+    pathname = pathname.replace(base, "");
+  }
   if (pathname in redirects) {
-    return redirect(301, redirects[pathname]);
+    return redirect(301, base + redirects[pathname]);
   }
 }


### PR DESCRIPTION
This PR fixes a CI build regression introduced in #535. The prerendered redirects didn't take into account the optional `BASE_PATH` which we use for the github pages build, causing build failures (see e.g. [this run](https://github.com/minvws/nl-rdo-manon/actions/runs/9060539218/job/24912795385)).