### PR TITLE
fix: Header wrapping behaviour basic bold theme

### DIFF
--- a/themes/basic-bold/components/header-content-wrapper.scss
+++ b/themes/basic-bold/components/header-content-wrapper.scss
@@ -5,4 +5,5 @@
   --header-content-wrapper-padding-right: 0;
   --header-content-wrapper-padding-left: 0;
   --header-content-wrapper-flex-direction: column;
+  --header-content-wrapper-flex-wrap: nowrap;
 }


### PR DESCRIPTION
Fixes wrapping behaviour of header-content-wrapper within basic-bold theme