### PR TITLE
Fix links svelte icore docs

### DIFF
--- a/icore_open_docs/src/routes/(docs)/components/notification-explanation/+page.svelte
+++ b/icore_open_docs/src/routes/(docs)/components/notification-explanation/+page.svelte
@@ -175,21 +175,6 @@
 `}
         />
 
-        <h3 id="explanation-table">Tabel-elementen</h3>
-        <nav aria-label="Toelichting tabelelementen subnavigatie">
-          <ul>
-            <li>
-              <a href="#explanation-th">Tabeltitel - <code>th</code></a>
-            </li>
-            <li>
-              <a href="#explanation-td">Tabelcel - <code>td</code></a>
-            </li>
-            <li>
-              <a href="#explanation-tr">Tabelrij - <code>tr</code></a>
-            </li>
-          </ul>
-        </nav>
-
         <h3 id="explanation-form">Formulier-elementen</h3>
         <nav aria-label="Toelichting formulierelementen subnavigatie">
           <ul>

--- a/icore_open_docs/src/routes/(docs)/components/table-base/+page.svelte
+++ b/icore_open_docs/src/routes/(docs)/components/table-base/+page.svelte
@@ -17,7 +17,6 @@
     <ul>
       <li><a href="#introduction">Introductie</a></li>
       <li><a href="#examples">Voorbeelden</a></li>
-      <li><a href="#requirements">Benodigde bestanden</a></li>
     </ul>
   </SideMenu>
   <article class="visually-grouped">


### PR DESCRIPTION
Currently the svelte build for icore docs crashes because the href targets were not found.

This removes the href links and the docs can be build again.