### PR TITLE
fix: icore-open font-faces

### DIFF
--- a/themes/icore-open/fonts/fonts.scss
+++ b/themes/icore-open/fonts/fonts.scss
@@ -5,40 +5,36 @@
 /* IBM Plex Sans */
 /* Regular */
 @font-face {
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: "IBM Plex Sans";
   font-weight: normal;
   font-style: normal;
   font-display: var(--text-body-font-display, swap);
-  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-Regular.ttf")
-    format("ttf");
+  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-Regular.ttf");
 }
 
 @font-face {
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: "IBM Plex Sans";
   font-weight: normal;
   font-style: italic;
   font-display: var(--text-body-font-display, swap);
-  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-Italic.ttf")
-    format("ttf");
+  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-Italic.ttf");
 }
 
 /* Semi bold */
 @font-face {
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: "IBM Plex Sans";
   font-weight: 600;
   font-style: normal;
   font-display: var(--text-body-font-display, swap);
-  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBold.ttf")
-    format("ttf");
+  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBold.ttf");
 }
 
 @font-face {
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: "IBM Plex Sans";
   font-weight: 600;
   font-style: italic;
   font-display: var(--text-body-font-display, swap);
-  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBoldItalic.ttf")
-    format("ttf");
+  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBoldItalic.ttf") format("truetype");
 }
 
 /* Icon font */

--- a/themes/icore-open/fonts/fonts.scss
+++ b/themes/icore-open/fonts/fonts.scss
@@ -34,7 +34,7 @@
   font-weight: 600;
   font-style: italic;
   font-display: var(--text-body-font-display, swap);
-  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBoldItalic.ttf") format("truetype");
+  src: url("#{variables.$font-path}/IBMPlexSans/IBMPlexSans-SemiBoldItalic.ttf");
 }
 
 /* Icon font */


### PR DESCRIPTION
This PR fixes the icore-open theme's `@font-face` rules.

The regular [`font-family` property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) takes a list of fonts, but the `@font-face`'s [`font-family` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family) only takes the font's name. Adding a `sans-serif` "fallback" causes issues.