### PR TITLE
fix: remove source code comment from docs Code component

### DIFF
--- a/docs/src/lib/Code.svelte
+++ b/docs/src/lib/Code.svelte
@@ -24,9 +24,6 @@
   $: highlighted = hljs.highlight(trimmed, { language }).value;
 </script>
 
-{@html `<!--
-${trimmed}
--->`}
 <pre><code>{@html highlighted}</code></pre>
 
 <style>

--- a/icore_open_docs/src/lib/Code.svelte
+++ b/icore_open_docs/src/lib/Code.svelte
@@ -24,9 +24,6 @@
   $: highlighted = hljs.highlight(trimmed, { language }).value;
 </script>
 
-{@html `<!--
-${trimmed}
--->`}
 <pre><code>{@html highlighted}</code></pre>
 
 <style>


### PR DESCRIPTION
This PR fixes the issue where some code blocks were rendered incorrectly due to unescaped comments in the commented plaintext version of the highlighted Code blocks.

As reported by @ricklambrechts:
![image](https://github.com/user-attachments/assets/51763e8e-67c2-4ed4-bdb9-cc56598648d3)
