### PR TITLE
fix: breadcrumb base path

### DIFF
--- a/docs/src/lib/BreadcrumbNav.svelte
+++ b/docs/src/lib/BreadcrumbNav.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { base } from "$app/paths";
   import { page } from "$app/stores";
   import { getBreadcrumbs } from "$lib/breadcrumbs.js";
   import NavLink from "./NavLink.svelte";
@@ -10,7 +11,7 @@
     <div>
       <ul>
         {#each breadcrumbs as crumb}
-          <li><NavLink href={crumb.route}>{crumb.name}</NavLink></li>
+          <li><NavLink href="{base}{crumb.route}">{crumb.name}</NavLink></li>
         {/each}
       </ul>
     </div>

--- a/icore_open_docs/src/lib/BreadcrumbNav.svelte
+++ b/icore_open_docs/src/lib/BreadcrumbNav.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { base } from "$app/paths";
   import { page } from "$app/stores";
   import { getBreadcrumbs } from "$lib/breadcrumbs.js";
   import NavLink from "./NavLink.svelte";
@@ -10,7 +11,7 @@
     <div>
       <ul>
         {#each breadcrumbs as crumb}
-          <li><NavLink href={crumb.route}>{crumb.name}</NavLink></li>
+          <li><NavLink href="{base}{crumb.route}">{crumb.name}</NavLink></li>
         {/each}
       </ul>
     </div>


### PR DESCRIPTION
Add the missing base path to the docs' breadcrumb links (e.g. for github pages).
