### PR TITLE
ci: fix github-pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,19 +30,8 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --ignore-scripts
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Build the documentation
         working-directory: docs


### PR DESCRIPTION
This PR attempts to fix a regression from #590, which causes the `github-pages` workflow to fail because it explicitly uses pnpm 8. This PR changes the workflow to use the same `setup` action as the `ci` workflow.