### PR TITLE
chore: fix deprecation warning about sass mixed declarations

### DIFF
--- a/manon/header-navigation-button.scss
+++ b/manon/header-navigation-button.scss
@@ -15,16 +15,18 @@ body > header,
     input[type="reset"] {
       @include link.link("header-navigation-button-");
 
-      justify-content: var(--header-navigation-button-justify-content);
-      align-self: var(--header-navigation-button-align-self);
-      min-width: var(--header-navigation-button-min-width);
-      min-height: var(--header-navigation-button-min-height);
-      height: var(--header-navigation-button-height);
+      & {
+        justify-content: var(--header-navigation-button-justify-content);
+        align-self: var(--header-navigation-button-align-self);
+        min-width: var(--header-navigation-button-min-width);
+        min-height: var(--header-navigation-button-min-height);
+        height: var(--header-navigation-button-height);
 
-      padding-top: var(--header-navigation-button-padding-top);
-      padding-right: var(--header-navigation-button-padding-right);
-      padding-bottom: var(--header-navigation-button-padding-bottom);
-      padding-left: var(--header-navigation-button-padding-left);
+        padding-top: var(--header-navigation-button-padding-top);
+        padding-right: var(--header-navigation-button-padding-right);
+        padding-bottom: var(--header-navigation-button-padding-bottom);
+        padding-left: var(--header-navigation-button-padding-left);
+      }
     }
   }
 }

--- a/manon/header-navigation-link.scss
+++ b/manon/header-navigation-link.scss
@@ -12,15 +12,17 @@ body > header,
     a {
       @include link.link("header-navigation-link-");
 
-      height: 100%;
-      display: inline-flex;
-      align-items: var(--header-navigation-link-align-items);
-      justify-content: var(--header-navigation-link-justify-content);
-      padding-top: var(--header-navigation-link-padding-top);
-      padding-right: var(--header-navigation-link-padding-right);
-      padding-bottom: var(--header-navigation-link-padding-bottom);
-      padding-left: var(--header-navigation-link-padding-left);
-      min-height: var(--header-navigation-link-min-height);
+      & {
+        height: 100%;
+        display: inline-flex;
+        align-items: var(--header-navigation-link-align-items);
+        justify-content: var(--header-navigation-link-justify-content);
+        padding-top: var(--header-navigation-link-padding-top);
+        padding-right: var(--header-navigation-link-padding-right);
+        padding-bottom: var(--header-navigation-link-padding-bottom);
+        padding-left: var(--header-navigation-link-padding-left);
+        min-height: var(--header-navigation-link-min-height);
+      }
     }
   }
 }

--- a/manon/mixins/link.scss
+++ b/manon/mixins/link.scss
@@ -20,7 +20,9 @@ $states: ("visited", "hover", "active", "focus");
 }
 
 @mixin link-and-icon-styling($prefix) {
-  @include styling($prefix);
+  & {
+    @include styling($prefix);
+  }
 
   &::before,
   .icon::before {
@@ -29,7 +31,9 @@ $states: ("visited", "hover", "active", "focus");
 }
 
 @mixin link($prefix) {
-  @include styling($prefix);
+  & {
+    @include styling($prefix);
+  }
 
   &::before {
     @include icon.icon-format($prefix);

--- a/manon/mixins/notification-type.scss
+++ b/manon/mixins/notification-type.scss
@@ -3,11 +3,13 @@
 /*---------------------------------------------------------------------*/
 
 @mixin notification-type($type) {
-  background-color: var(--notification-#{$type}-background-color);
-  color: var(--notification-#{$type}-text-color);
-  border-width: var(--notification-#{$type}-border-width);
-  border-style: var(--notification-#{$type}-border-style);
-  border-color: var(--notification-#{$type}-border-color);
+  & {
+    background-color: var(--notification-#{$type}-background-color);
+    color: var(--notification-#{$type}-text-color);
+    border-width: var(--notification-#{$type}-border-width);
+    border-style: var(--notification-#{$type}-border-style);
+    border-color: var(--notification-#{$type}-border-color);
+  }
 
   &::before {
     font-family: var(--notification-#{$type}-icon-font-family);
@@ -49,11 +51,14 @@
 
 @mixin notification-page-type($type) {
   @include notification-type($type);
-  padding-top: var(--notification-#{$type}-page-padding-top);
-  padding-right: var(--notification-#{$type}-page-padding-right);
-  padding-bottom: var(--notification-#{$type}-page-padding-bottom);
-  padding-left: var(--notification-#{$type}-page-padding-left);
-  gap: var(--notification-#{$type}-page-gap);
+
+  & {
+    padding-top: var(--notification-#{$type}-page-padding-top);
+    padding-right: var(--notification-#{$type}-page-padding-right);
+    padding-bottom: var(--notification-#{$type}-page-padding-bottom);
+    padding-left: var(--notification-#{$type}-page-padding-left);
+    gap: var(--notification-#{$type}-page-gap);
+  }
 
   span:first-of-type {
     font-weight: var(--notification-#{$type}-page-span-font-weight);

--- a/manon/mixins/outline.scss
+++ b/manon/mixins/outline.scss
@@ -1,9 +1,11 @@
 @mixin outline($prefix) {
-  outline: var(--#{$prefix}outline);
-  outline-offset: var(--#{$prefix}outline-offset);
-  z-index: var(--#{$prefix}z-index, 1);
-  box-shadow: var(--#{$prefix}box-shadow);
-  border-radius: var(--#{$prefix}border-radius);
+  & {
+    outline: var(--#{$prefix}outline);
+    outline-offset: var(--#{$prefix}outline-offset);
+    z-index: var(--#{$prefix}z-index, 1);
+    box-shadow: var(--#{$prefix}box-shadow);
+    border-radius: var(--#{$prefix}border-radius);
+  }
 }
 
 @mixin outline-variables($prefix, $parentPrefix) {


### PR DESCRIPTION
Fix the deprecation warning Sass is giving about their [breaking change for nested rules](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) by opting into the new behaviour by wrapping the declarations in question in `& { }` blocks.