### PR TITLE
ci: disable stylelint 'no-duplicate-selectors' rule

### DIFF
--- a/manon/.stylelintrc.json
+++ b/manon/.stylelintrc.json
@@ -21,6 +21,7 @@
         "severity": "warning"
       }
     ],
+    "no-duplicate-selectors": null,
     "number-max-precision": 5,
     "property-no-vendor-prefix": null,
     "scss/operator-no-newline-after": null,


### PR DESCRIPTION
Disable stylelint's "no-duplicate-selectors" rule, as duplicate selectors are unavoidable with #627.