### PR TITLE
fix: radio button and checkboxes docs

### DIFF
--- a/docs/src/routes/(docs)/components/checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/checkbox/+page.svelte
@@ -259,7 +259,9 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="{base}/documentation/import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/documentation/import-styling"
+            >Componenten gebruiken en styling toevoegen</a
+          >
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -268,7 +270,7 @@
         <Code
           language="css"
           code={`
-@use "@minvws/checkbox";
+@use "@minvws/manon/checkbox";
 `}
         />
       </section>

--- a/docs/src/routes/(docs)/components/fieldset-checkbox/+page.svelte
+++ b/docs/src/routes/(docs)/components/fieldset-checkbox/+page.svelte
@@ -282,7 +282,9 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="{base}/documentation/import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/documentation/import-styling"
+            >Componenten gebruiken en styling toevoegen</a
+          >
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -291,7 +293,8 @@
         <Code
           language="css"
           code={`
-@use "@minvws/form-fieldset-checkbox";
+@use "@minvws/manon/checkbox";
+@use "@minvws/manon/form-fieldset-checkbox";
 `}
         />
       </section>

--- a/docs/src/routes/(docs)/components/fieldset-radio/+page.svelte
+++ b/docs/src/routes/(docs)/components/fieldset-radio/+page.svelte
@@ -255,7 +255,9 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="{base}/documentation/import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/documentation/import-styling"
+            >Componenten gebruiken en styling toevoegen</a
+          >
         </p>
 
         <h3>Importeer component via NPM</h3>
@@ -264,7 +266,7 @@
         <Code
           language="css"
           code={`
-@use "@minvws/form-fieldset-radio";
+@use "@minvws/manon/form-fieldset-radio";
 `}
         />
       </section>

--- a/docs/src/routes/(docs)/components/form-input-radio/+page.svelte
+++ b/docs/src/routes/(docs)/components/form-input-radio/+page.svelte
@@ -131,7 +131,9 @@
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:
-          <a href="{base}/documentation/import-styling">Componenten gebruiken en styling toevoegen</a>
+          <a href="{base}/documentation/import-styling"
+            >Componenten gebruiken en styling toevoegen</a
+          >
         </p>
 
         <h3>Aandachtspunten:</h3>
@@ -150,7 +152,8 @@
         <Code
           language="css"
           code={`
-@use "@minvws/form-radio";
+@use "@minvws/manon/radio";
+@use "@minvws/manon/form-radio";
 `}
         />
       </section>

--- a/icore_open_docs/src/routes/(docs)/components/form-input-radio/+page.svelte
+++ b/icore_open_docs/src/routes/(docs)/components/form-input-radio/+page.svelte
@@ -152,7 +152,8 @@
         <Code
           language="css"
           code={`
-@use "@minvws/form-radio";
+@use "@minvws/manon/radio";
+@use "@minvws/manon/form-radio";
 `}
         />
       </section>


### PR DESCRIPTION
Radio button styling didn't work. The reference to the imports was incorrect in the documentation. I've updated the docs to match the current situation. Also checked the other components for any old references and fixed those. 

Closes: https://github.com/minvws/nl-rdo-manon/issues/622
