### PR TITLE
ci: ignore CVE-2024-45047

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "pnpm": {
     "overrides": {
       "micromatch@<4.0.8": ">=4.0.8"
+    },
+    "auditConfig": {
+      "ignoreCves": [
+        "CVE-2024-45047"
+      ]
     }
   }
 }


### PR DESCRIPTION
Add an `auditConfig` to package.json once again, this time to ignore CVE-2024-45047. The docs site is not vulnerable as it does not have any `<noscript>` tags.
