### PR TITLE
fix(docs): writing style pseudo selectors and pseudo elements

### DIFF
--- a/docs/src/routes/(docs)/components/accordion/+page.svelte
+++ b/docs/src/routes/(docs)/components/accordion/+page.svelte
@@ -404,17 +404,17 @@
             </ul>
           </li>
           <li>
-            Open en sluit icoon. Keuze uit <code>:before</code> of
-            <code>:after</code>
+            Open en sluit icoon. Keuze uit <code>::before</code> of
+            <code>::after</code>
             <ul>
               <li>
-                <code>:before</code>
+                <code>::before</code>
                 <ul>
                   <li><a href="{base}/documentation/variables#icon">icon</a></li>
                 </ul>
               </li>
               <li>
-                <code>:after</code>
+                <code>::after</code>
                 <ul>
                   <li><a href="{base}/documentation/variables#icon">icon</a></li>
                   <li>

--- a/docs/src/routes/(docs)/components/link/+page.svelte
+++ b/docs/src/routes/(docs)/components/link/+page.svelte
@@ -47,15 +47,15 @@
 
         <h4>Visueel voorbeeld:</h4>
         <a href="link">Basis</a>
-        <a href="link" class="icon icon-cat">Met <code>:before</code></a>
+        <a href="link" class="icon icon-cat">Met <code>::before</code></a>
         <a href="link" class="icon-after icon-cat"
-          >Met <code>:after</code><span class="icon icon-cat">Kat icoon</span></a
+          >Met <code>::after</code><span class="icon icon-cat">Kat icoon</span></a
         >
 
         <a href="link" class="hover">Hover <code>:hover</code></a>
-        <a href="link" class="hover icon icon-cat">Hover met <code>:before:hover</code></a>
+        <a href="link" class="hover icon icon-cat">Hover met <code>::before:hover</code></a>
         <a href="link" class="hover"
-          >Hover met <code>:before:hover</code> <span class="icon icon-cat"></span></a
+          >Hover met <code>::before:hover</code> <span class="icon icon-cat"></span></a
         >
 
         <a href="link" class="active">Actieve link</a>

--- a/docs/src/routes/(docs)/components/navigation/+page.svelte
+++ b/docs/src/routes/(docs)/components/navigation/+page.svelte
@@ -49,10 +49,10 @@
         <nav>
           <ul>
             <li><a href="navigation">Basis</a></li>
-            <li><a href="navigation" class="icon icon-cat">Met <code>:before</code></a></li>
+            <li><a href="navigation" class="icon icon-cat">Met <code>::before</code></a></li>
             <li>
               <a href="navigation" class="icon-after icon-cat"
-                >Met <code>:after</code><span class="icon icon-cat">Kat icoon</span></a
+                >Met <code>::after</code><span class="icon icon-cat">Kat icoon</span></a
               >
             </li>
 
@@ -60,12 +60,12 @@
 
             <li>
               <a href="navigation" class="hover icon icon-cat"
-                >Hover met <code>:before:hover</code></a
+                >Hover met <code>::before:hover</code></a
               >
             </li>
             <li>
               <a href="navigation" class="hover"
-                >Hover met <code>:before:hover</code> <span class="icon icon-cat"></span></a
+                >Hover met <code>::before:hover</code> <span class="icon icon-cat"></span></a
               >
             </li>
 
@@ -199,12 +199,12 @@
             <li><a href="#nav-a-hover" class="hover">Lorem ipsum</a></li>
             <li>
               <a href="#nav-a-hover" class="hover icon icon-cat"
-                >Hover met <code>:before:hover</code></a
+                >Hover met <code>::before:hover</code></a
               >
             </li>
             <li>
               <a href="#nav-a-hover" class="hover"
-                >Hover met <code>:before:hover</code> <span class="icon icon-cat"></span></a
+                >Hover met <code>::before:hover</code> <span class="icon icon-cat"></span></a
               >
             </li>
           </ul>
@@ -217,8 +217,8 @@
 <nav>
     <ul>
         <li><a href="#" class="hover">Lorem ipsum</a></li>
-        <li><a href="#" class="hover icon icon-cat">Hover met <code>:before:hover</code></a></li>
-        <li><a href="#" class="hover">Hover met <code>:before:hover</code> <span class="icon icon-cat"></span></a></li>
+        <li><a href="#" class="hover icon icon-cat">Hover met <code>::before:hover</code></a></li>
+        <li><a href="#" class="hover">Hover met <code>::before:hover</code> <span class="icon icon-cat"></span></a></li>
     </ul>
 </nav>
 `}
@@ -230,12 +230,12 @@
             <li><a href="#nav-a-active" class="active">Lorem ipsum</a></li>
             <li>
               <a href="#nav-a-active" class="active icon icon-cat"
-                >active met <code>:before:active</code></a
+                >active met <code>::before:active</code></a
               >
             </li>
             <li>
               <a href="#nav-a-active" class="active"
-                >active met <code>:before:active</code> <span class="icon icon-cat"></span></a
+                >active met <code>::before:active</code> <span class="icon icon-cat"></span></a
               >
             </li>
           </ul>
@@ -248,8 +248,8 @@
 <nav>
     <ul>
         <li><a href="#" class="active">Lorem ipsum</a></li>
-        <li><a href="#" class="active icon icon-cat">active met <code>:before:active</code></a></li>
-        <li><a href="#" class="active">active met <code>:before:active</code> <span class="icon icon-cat"></span></a></li>
+        <li><a href="#" class="active icon icon-cat">active met <code>::before:active</code></a></li>
+        <li><a href="#" class="active">active met <code>::before:active</code> <span class="icon icon-cat"></span></a></li>
     </ul>
 </nav>
 `}


### PR DESCRIPTION
Closes https://github.com/minvws/nl-rdo-manon/issues/361

I used https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#list_of_pseudo-elements as a reference and search.replaced all psuedo elements in Manon that I could find.

- :before is now ::before
- :after is now ::after

But I did not change for example :active because it is not a pseudo-element, it is a pseudo-class

I needed to make sure that I did not end up with after a 'search and replace' with something like this: `:::`after` so I did something else first:

- I searched for all existing correct pseudo-elements and swapped the characters.
- I now searched for `:after` and replaced it with `::retfa`
- as a final step I searched for all `::retfa` and replaced them with `::after`

<img width="267" alt="Scherm­afbeelding 2024-09-26 om 20 01 45" src="https://github.com/user-attachments/assets/1e209b35-85e5-45df-a91f-af1287da5ad6">

Same method for the `::before` element 
