### PR TITLE
fix: icore-open table row header border

### DIFF
--- a/docs/src/routes/(docs)/components/table-base/+page.svelte
+++ b/docs/src/routes/(docs)/components/table-base/+page.svelte
@@ -16,7 +16,14 @@
   <SideMenu>
     <ul>
       <li><a href="#introduction">Introductie</a></li>
-      <li><a href="#examples">Voorbeelden</a></li>
+      <li>
+        <a href="#examples">Voorbeelden</a>
+        <ul>
+          <li><a href="#example-base">Basis</a></li>
+          <li><a href="#example-footer">Tabel met footer</a></li>
+          <li><a href="#example-row-headers">Tabel met rij-headers</a></li>
+        </ul>
+      </li>
       <li><a href="#requirements">Benodigde bestanden</a></li>
     </ul>
   </SideMenu>
@@ -37,38 +44,38 @@
 
         <h2>Voorbeelden</h2>
 
-        <h3>Basis</h3>
+        <h3 id="example-base">Basis</h3>
         <h4>Visueel voorbeeld</h4>
         <div class="horizontal-scroll">
           <table>
-            <caption> Basisvoorbeeld tabel: </caption>
+            <caption>Basisvoorbeeld tabel:</caption>
             <thead>
               <tr>
-                <th scope="col">Table header heading 1</th>
-                <th scope="col">Table header heading 2</th>
-                <th scope="col">Table header heading 3</th>
+                <th scope="col">Kolom 1</th>
+                <th scope="col">Kolom 2</th>
+                <th scope="col">Kolom 3</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
             </tbody>
           </table>
@@ -83,31 +90,31 @@
     <caption>Basisvoorbeeld tabel:</caption>
     <thead>
       <tr>
-        <th scope="col">Table header heading 1</th>
-        <th scope="col">Table header heading 2</th>
-        <th scope="col">Table header heading 3</th>
+        <th scope="col">Kolom 1</th>
+        <th scope="col">Kolom 2</th>
+        <th scope="col">Kolom 3</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
     </tbody>
   </table>
@@ -115,38 +122,38 @@
 `}
         />
 
-        <h2>Tabel met footer</h2>
+        <h3 id="example-footer">Tabel met footer</h3>
         <p>
           Om de gebruiker te informeren over de inhoud van de tabel, is het aan te raden om een
           titel toe te voegen met daarin de omschrijving van de tabel. Voeg direct binnen de
           <code>table</code> een <code>caption</code> toe om de titel toe te voegen.
         </p>
-        <p>Visueel voorbeeld:</p>
+        <h4>Visueel voorbeeld:</h4>
         <div class="horizontal-scroll">
           <table>
-            <caption> Tabelvoorbeeld met footer: </caption>
+            <caption>Tabelvoorbeeld met footer:</caption>
             <thead>
               <tr>
-                <th scope="col">Table header heading 1</th>
-                <th scope="col">Table header heading 2</th>
-                <th scope="col">Table header heading 3</th>
+                <th scope="col">Kolom 1</th>
+                <th scope="col">Kolom 2</th>
+                <th scope="col">Kolom 3</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
               <tr>
                 <td>Lorem</td>
                 <td>Ipsum</td>
-                <td>Dolor set</td>
+                <td>Dolor sit amet</td>
               </tr>
             </tbody>
             <tfoot>
@@ -170,29 +177,29 @@
           code={`
 <div class="horizontal-scroll">
   <table>
-    <caption>Table with titlebar and title example:</caption>
+    <caption>Tabelvoorbeeld met footer:</caption>
     <thead>
       <tr>
-        <th scope="col">Table header heading 1</th>
-        <th scope="col">Table header heading 2</th>
-        <th scope="col">Table header heading 3</th>
+        <th scope="col">Kolom 1</th>
+        <th scope="col">Kolom 2</th>
+        <th scope="col">Kolom 3</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
       <tr>
         <td>Lorem</td>
         <td>Ipsum</td>
-        <td>Dolor set</td>
+        <td>Dolor sit amet</td>
       </tr>
     </tbody>
     <tfoot>
@@ -207,6 +214,84 @@
         <td>Table footer 3</td>
       </tr>
     </tfoot>
+  </table>
+</div>
+`}
+        />
+
+        <h3 id="example-row-headers">Tabel met rij-headers</h3>
+        <h4>Visueel voorbeeld</h4>
+        <div class="horizontal-scroll">
+          <table>
+            <caption>Basisvoorbeeld tabel met rij-headers:</caption>
+            <thead>
+              <tr>
+                <th scope="col">Kolom 1</th>
+                <th scope="col">Kolom 2</th>
+                <th scope="col">Kolom 3</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Rij 1</th>
+                <td>Lorem ipsum</td>
+                <td>Dolor sit amet</td>
+              </tr>
+              <tr>
+                <th scope="row">Rij 2</th>
+                <td>Lorem ipsum</td>
+                <td>Dolor sit amet</td>
+              </tr>
+              <tr>
+                <th scope="row">Rij 3</th>
+                <td>Lorem ipsum</td>
+                <td>Dolor sit amet</td>
+              </tr>
+              <tr>
+                <th scope="row">Rij 4</th>
+                <td>Lorem ipsum</td>
+                <td>Dolor sit amet</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h4>HTML-voorbeeld:</h4>
+        <Code
+          language="html"
+          code={`
+<div class="horizontal-scroll">
+  <table>
+    <caption>Basisvoorbeeld tabel:</caption>
+    <thead>
+      <tr>
+        <th scope="col">Kolom 1</th>
+        <th scope="col">Kolom 2</th>
+        <th scope="col">Kolom 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Lorem</td>
+        <td>Ipsum</td>
+        <td>Dolor sit amet</td>
+      </tr>
+      <tr>
+        <td>Lorem</td>
+        <td>Ipsum</td>
+        <td>Dolor sit amet</td>
+      </tr>
+      <tr>
+        <td>Lorem</td>
+        <td>Ipsum</td>
+        <td>Dolor sit amet</td>
+      </tr>
+      <tr>
+        <td>Lorem</td>
+        <td>Ipsum</td>
+        <td>Dolor sit amet</td>
+      </tr>
+    </tbody>
   </table>
 </div>
 `}

--- a/themes/icore-open/components/table.scss
+++ b/themes/icore-open/components/table.scss
@@ -22,7 +22,7 @@
   --table-head-cell-font-size: 1rem;
 
   /* Table body header */
-  --table-body-head-cell-border-width: 0;
+  --table-body-head-cell-border-width: 0 0 1px 0;
   --table-body-head-cell-background-color: transparent;
 
   /* Table cell */


### PR DESCRIPTION
Fix the `--table-body-head-cell-border-width` of the icore-open theme.

Before|After
------|-----
![Screen Shot 2024-10-17 at 16 17 10](https://github.com/user-attachments/assets/e04b2da0-04a3-4659-8aea-e8799ff415f9)|![Screen Shot 2024-10-17 at 16 17 26](https://github.com/user-attachments/assets/9d1a7345-de89-4669-b9e4-6ec0a2b669d5)
