### PR TITLE
ci: separate npm audit job

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "Registry URL to setup up for auth. Passed on to actions/setup-node."
     default: ""
   audit-level:
-    description: "npm audit-level <info|low|moderate|high|ciritical|none>"
+    description: "npm audit-level <info|low|moderate|high|critical|none>"
     default: "high"
 
 runs:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,9 +3,11 @@ description: "Setup Node.js and pnpm and install dependencies"
 
 inputs:
   registry-url:
-    required: false
     description: "Registry URL to setup up for auth. Passed on to actions/setup-node."
     default: ""
+  audit-level:
+    description: "npm audit-level <info|low|moderate|high|ciritical|none>"
+    default: "high"
 
 runs:
   using: "composite"
@@ -34,7 +36,7 @@ runs:
 
     - name: Audit dependencies
       shell: bash
-      run: pnpm audit
+      run: pnpm audit --audit-level=${{ inputs.audit-level }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
     branches: [main]
 
 jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Audit dependencies
+        uses: ./.github/actions/setup
+        with:
+          audit-level: moderate
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - name: Check formatting
+      - name: Run svelte-check on docs
         run: pnpm run --dir docs check
 
   build-docs:
@@ -35,5 +44,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - name: Build Docs
+      - name: Build docs
         run: pnpm run build


### PR DESCRIPTION
Add a separate CI job for npm audit and change the regular pre-install audit's severity level to "high". See #557.
