### PR TITLE
ci: fix ci workflow trigger events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
 
 jobs:
   lint:


### PR DESCRIPTION
Fix the CI workflow's trigger events to stop it from running for every push to any branch.
