### PR TITLE
fix: header navigation current link styles

### DIFF
--- a/manon/header-navigation-link-focus-variables.scss
+++ b/manon/header-navigation-link-focus-variables.scss
@@ -12,6 +12,11 @@
     "navigation-link-focus-"
   );
 
+  @include link.styling-variables(
+    "header-navigation-current-link-focus-",
+    "header-navigation-link-focus-"
+  );
+
   /* Link focus outline */
   @include outline.outline-variables("header-navigation-link-focus-", initial);
 

--- a/manon/header-navigation-link-focus-variables.scss
+++ b/manon/header-navigation-link-focus-variables.scss
@@ -11,7 +11,6 @@
     "header-navigation-link-focus-",
     "navigation-link-focus-"
   );
-
   @include link.styling-variables(
     "header-navigation-current-link-focus-",
     "header-navigation-link-focus-"

--- a/manon/header-navigation-link-focus.scss
+++ b/manon/header-navigation-link-focus.scss
@@ -29,8 +29,6 @@ body > header,
 
     a[aria-current="page"],
     a[aria-current="page"]:visited {
-      @extend %header-navigation-current-link-focus-styling;
-
       &:focus {
         @extend %header-navigation-current-link-focus-styling;
         @extend %header-navigation-link-focus-outline;


### PR DESCRIPTION
Currently with [theme v0.1.0-beta.2](https://github.com/minvws/nl-rdo-rijksoverheid-ui-theme/releases/tag/v0.1.0-beta.2) and [manon v17.0.0-beta.1](https://github.com/minvws/nl-rdo-manon/releases/tag/v17.0.0-beta.1) the current link looks like:

![image](https://github.com/user-attachments/assets/64069065-ff2a-4c33-9897-8b0f8f30d836)

The `Flow` item should look active. 

Chrome Dev tools is showing that the current-link-focus variables are missing, but these variables should not be needed for only the current link styling.
![image](https://github.com/user-attachments/assets/a5f290fb-64ee-4561-9a72-06ecd1f7cdac)

Current link styling should come from here:
https://github.com/minvws/nl-rdo-manon/blob/fa0ae27c478da0f4b4672cae34f68496acdbb995/manon/header-navigation-link-active.scss#L24-L27

Instead from, so I removed the `@extend` line.
https://github.com/minvws/nl-rdo-manon/blob/fa0ae27c478da0f4b4672cae34f68496acdbb995/manon/header-navigation-link-focus.scss#L30-L33

Also the current link focus variables are still missing, so I default them to the focus variables.

After these changes the active item looks good.

![image](https://github.com/user-attachments/assets/b98bf1e5-9eb9-43e5-87e3-d4a391751de9)
