### PR TITLE
fix: default header-navigation-link-focus-outline

### DIFF
--- a/manon/header-navigation-link-focus-variables.scss
+++ b/manon/header-navigation-link-focus-variables.scss
@@ -17,7 +17,10 @@
   );
 
   /* Link focus outline */
-  @include outline.outline-variables("header-navigation-link-focus-", initial);
+  @include outline.outline-variables(
+    "header-navigation-link-focus-",
+    "navigation-link-focus-"
+  );
 
   /* Icon */
   @include link.icon-styling-variables(


### PR DESCRIPTION
Use `navigation-link-focus-*` as fallback for `header-navigation-link-focus-*` to fix header navigation link focus outline styles in themes that do not specify them.