### PR TITLE
fix: actually resolve map-get deprecation warning

### DIFF
--- a/themes/icore-open/color-scheme/open-color.scss
+++ b/themes/icore-open/color-scheme/open-color.scss
@@ -31,16 +31,16 @@ $oc-gray-list: (
   "9": #212529,
 );
 
-$oc-gray-0: map-get($oc-gray-list, "0");
-$oc-gray-1: map-get($oc-gray-list, "1");
-$oc-gray-2: map-get($oc-gray-list, "2");
-$oc-gray-3: map-get($oc-gray-list, "3");
-$oc-gray-4: map-get($oc-gray-list, "4");
-$oc-gray-5: map-get($oc-gray-list, "5");
-$oc-gray-6: map-get($oc-gray-list, "6");
-$oc-gray-7: map-get($oc-gray-list, "7");
-$oc-gray-8: map-get($oc-gray-list, "8");
-$oc-gray-9: map-get($oc-gray-list, "9");
+$oc-gray-0: map.get($oc-gray-list, "0");
+$oc-gray-1: map.get($oc-gray-list, "1");
+$oc-gray-2: map.get($oc-gray-list, "2");
+$oc-gray-3: map.get($oc-gray-list, "3");
+$oc-gray-4: map.get($oc-gray-list, "4");
+$oc-gray-5: map.get($oc-gray-list, "5");
+$oc-gray-6: map.get($oc-gray-list, "6");
+$oc-gray-7: map.get($oc-gray-list, "7");
+$oc-gray-8: map.get($oc-gray-list, "8");
+$oc-gray-9: map.get($oc-gray-list, "9");
 
 //  Red
 //  ───────────────────────────────────
@@ -58,16 +58,16 @@ $oc-red-list: (
   "9": #c92a2a,
 );
 
-$oc-red-0: map-get($oc-red-list, "0");
-$oc-red-1: map-get($oc-red-list, "1");
-$oc-red-2: map-get($oc-red-list, "2");
-$oc-red-3: map-get($oc-red-list, "3");
-$oc-red-4: map-get($oc-red-list, "4");
-$oc-red-5: map-get($oc-red-list, "5");
-$oc-red-6: map-get($oc-red-list, "6");
-$oc-red-7: map-get($oc-red-list, "7");
-$oc-red-8: map-get($oc-red-list, "8");
-$oc-red-9: map-get($oc-red-list, "9");
+$oc-red-0: map.get($oc-red-list, "0");
+$oc-red-1: map.get($oc-red-list, "1");
+$oc-red-2: map.get($oc-red-list, "2");
+$oc-red-3: map.get($oc-red-list, "3");
+$oc-red-4: map.get($oc-red-list, "4");
+$oc-red-5: map.get($oc-red-list, "5");
+$oc-red-6: map.get($oc-red-list, "6");
+$oc-red-7: map.get($oc-red-list, "7");
+$oc-red-8: map.get($oc-red-list, "8");
+$oc-red-9: map.get($oc-red-list, "9");
 
 //  Pink
 //  ───────────────────────────────────
@@ -85,16 +85,16 @@ $oc-pink-list: (
   "9": #a61e4d,
 );
 
-$oc-pink-0: map-get($oc-pink-list, "0");
-$oc-pink-1: map-get($oc-pink-list, "1");
-$oc-pink-2: map-get($oc-pink-list, "2");
-$oc-pink-3: map-get($oc-pink-list, "3");
-$oc-pink-4: map-get($oc-pink-list, "4");
-$oc-pink-5: map-get($oc-pink-list, "5");
-$oc-pink-6: map-get($oc-pink-list, "6");
-$oc-pink-7: map-get($oc-pink-list, "7");
-$oc-pink-8: map-get($oc-pink-list, "8");
-$oc-pink-9: map-get($oc-pink-list, "9");
+$oc-pink-0: map.get($oc-pink-list, "0");
+$oc-pink-1: map.get($oc-pink-list, "1");
+$oc-pink-2: map.get($oc-pink-list, "2");
+$oc-pink-3: map.get($oc-pink-list, "3");
+$oc-pink-4: map.get($oc-pink-list, "4");
+$oc-pink-5: map.get($oc-pink-list, "5");
+$oc-pink-6: map.get($oc-pink-list, "6");
+$oc-pink-7: map.get($oc-pink-list, "7");
+$oc-pink-8: map.get($oc-pink-list, "8");
+$oc-pink-9: map.get($oc-pink-list, "9");
 
 //  Grape
 //  ───────────────────────────────────
@@ -112,16 +112,16 @@ $oc-grape-list: (
   "9": #862e9c,
 );
 
-$oc-grape-0: map-get($oc-grape-list, "0");
-$oc-grape-1: map-get($oc-grape-list, "1");
-$oc-grape-2: map-get($oc-grape-list, "2");
-$oc-grape-3: map-get($oc-grape-list, "3");
-$oc-grape-4: map-get($oc-grape-list, "4");
-$oc-grape-5: map-get($oc-grape-list, "5");
-$oc-grape-6: map-get($oc-grape-list, "6");
-$oc-grape-7: map-get($oc-grape-list, "7");
-$oc-grape-8: map-get($oc-grape-list, "8");
-$oc-grape-9: map-get($oc-grape-list, "9");
+$oc-grape-0: map.get($oc-grape-list, "0");
+$oc-grape-1: map.get($oc-grape-list, "1");
+$oc-grape-2: map.get($oc-grape-list, "2");
+$oc-grape-3: map.get($oc-grape-list, "3");
+$oc-grape-4: map.get($oc-grape-list, "4");
+$oc-grape-5: map.get($oc-grape-list, "5");
+$oc-grape-6: map.get($oc-grape-list, "6");
+$oc-grape-7: map.get($oc-grape-list, "7");
+$oc-grape-8: map.get($oc-grape-list, "8");
+$oc-grape-9: map.get($oc-grape-list, "9");
 
 //  Violet
 //  ───────────────────────────────────
@@ -139,16 +139,16 @@ $oc-violet-list: (
   "9": #5f3dc4,
 );
 
-$oc-violet-0: map-get($oc-violet-list, "0");
-$oc-violet-1: map-get($oc-violet-list, "1");
-$oc-violet-2: map-get($oc-violet-list, "2");
-$oc-violet-3: map-get($oc-violet-list, "3");
-$oc-violet-4: map-get($oc-violet-list, "4");
-$oc-violet-5: map-get($oc-violet-list, "5");
-$oc-violet-6: map-get($oc-violet-list, "6");
-$oc-violet-7: map-get($oc-violet-list, "7");
-$oc-violet-8: map-get($oc-violet-list, "8");
-$oc-violet-9: map-get($oc-violet-list, "9");
+$oc-violet-0: map.get($oc-violet-list, "0");
+$oc-violet-1: map.get($oc-violet-list, "1");
+$oc-violet-2: map.get($oc-violet-list, "2");
+$oc-violet-3: map.get($oc-violet-list, "3");
+$oc-violet-4: map.get($oc-violet-list, "4");
+$oc-violet-5: map.get($oc-violet-list, "5");
+$oc-violet-6: map.get($oc-violet-list, "6");
+$oc-violet-7: map.get($oc-violet-list, "7");
+$oc-violet-8: map.get($oc-violet-list, "8");
+$oc-violet-9: map.get($oc-violet-list, "9");
 
 //  Indigo
 //  ───────────────────────────────────
@@ -166,16 +166,16 @@ $oc-indigo-list: (
   "9": #364fc7,
 );
 
-$oc-indigo-0: map-get($oc-indigo-list, "0");
-$oc-indigo-1: map-get($oc-indigo-list, "1");
-$oc-indigo-2: map-get($oc-indigo-list, "2");
-$oc-indigo-3: map-get($oc-indigo-list, "3");
-$oc-indigo-4: map-get($oc-indigo-list, "4");
-$oc-indigo-5: map-get($oc-indigo-list, "5");
-$oc-indigo-6: map-get($oc-indigo-list, "6");
-$oc-indigo-7: map-get($oc-indigo-list, "7");
-$oc-indigo-8: map-get($oc-indigo-list, "8");
-$oc-indigo-9: map-get($oc-indigo-list, "9");
+$oc-indigo-0: map.get($oc-indigo-list, "0");
+$oc-indigo-1: map.get($oc-indigo-list, "1");
+$oc-indigo-2: map.get($oc-indigo-list, "2");
+$oc-indigo-3: map.get($oc-indigo-list, "3");
+$oc-indigo-4: map.get($oc-indigo-list, "4");
+$oc-indigo-5: map.get($oc-indigo-list, "5");
+$oc-indigo-6: map.get($oc-indigo-list, "6");
+$oc-indigo-7: map.get($oc-indigo-list, "7");
+$oc-indigo-8: map.get($oc-indigo-list, "8");
+$oc-indigo-9: map.get($oc-indigo-list, "9");
 
 //  Blue
 //  ───────────────────────────────────
@@ -193,16 +193,16 @@ $oc-blue-list: (
   "9": #1864ab,
 );
 
-$oc-blue-0: map-get($oc-blue-list, "0");
-$oc-blue-1: map-get($oc-blue-list, "1");
-$oc-blue-2: map-get($oc-blue-list, "2");
-$oc-blue-3: map-get($oc-blue-list, "3");
-$oc-blue-4: map-get($oc-blue-list, "4");
-$oc-blue-5: map-get($oc-blue-list, "5");
-$oc-blue-6: map-get($oc-blue-list, "6");
-$oc-blue-7: map-get($oc-blue-list, "7");
-$oc-blue-8: map-get($oc-blue-list, "8");
-$oc-blue-9: map-get($oc-blue-list, "9");
+$oc-blue-0: map.get($oc-blue-list, "0");
+$oc-blue-1: map.get($oc-blue-list, "1");
+$oc-blue-2: map.get($oc-blue-list, "2");
+$oc-blue-3: map.get($oc-blue-list, "3");
+$oc-blue-4: map.get($oc-blue-list, "4");
+$oc-blue-5: map.get($oc-blue-list, "5");
+$oc-blue-6: map.get($oc-blue-list, "6");
+$oc-blue-7: map.get($oc-blue-list, "7");
+$oc-blue-8: map.get($oc-blue-list, "8");
+$oc-blue-9: map.get($oc-blue-list, "9");
 
 //  Cyan
 //  ───────────────────────────────────
@@ -220,16 +220,16 @@ $oc-cyan-list: (
   "9": #0b7285,
 );
 
-$oc-cyan-0: map-get($oc-cyan-list, "0");
-$oc-cyan-1: map-get($oc-cyan-list, "1");
-$oc-cyan-2: map-get($oc-cyan-list, "2");
-$oc-cyan-3: map-get($oc-cyan-list, "3");
-$oc-cyan-4: map-get($oc-cyan-list, "4");
-$oc-cyan-5: map-get($oc-cyan-list, "5");
-$oc-cyan-6: map-get($oc-cyan-list, "6");
-$oc-cyan-7: map-get($oc-cyan-list, "7");
-$oc-cyan-8: map-get($oc-cyan-list, "8");
-$oc-cyan-9: map-get($oc-cyan-list, "9");
+$oc-cyan-0: map.get($oc-cyan-list, "0");
+$oc-cyan-1: map.get($oc-cyan-list, "1");
+$oc-cyan-2: map.get($oc-cyan-list, "2");
+$oc-cyan-3: map.get($oc-cyan-list, "3");
+$oc-cyan-4: map.get($oc-cyan-list, "4");
+$oc-cyan-5: map.get($oc-cyan-list, "5");
+$oc-cyan-6: map.get($oc-cyan-list, "6");
+$oc-cyan-7: map.get($oc-cyan-list, "7");
+$oc-cyan-8: map.get($oc-cyan-list, "8");
+$oc-cyan-9: map.get($oc-cyan-list, "9");
 
 //  Teal
 //  ───────────────────────────────────
@@ -247,16 +247,16 @@ $oc-teal-list: (
   "9": #087f5b,
 );
 
-$oc-teal-0: map-get($oc-teal-list, "0");
-$oc-teal-1: map-get($oc-teal-list, "1");
-$oc-teal-2: map-get($oc-teal-list, "2");
-$oc-teal-3: map-get($oc-teal-list, "3");
-$oc-teal-4: map-get($oc-teal-list, "4");
-$oc-teal-5: map-get($oc-teal-list, "5");
-$oc-teal-6: map-get($oc-teal-list, "6");
-$oc-teal-7: map-get($oc-teal-list, "7");
-$oc-teal-8: map-get($oc-teal-list, "8");
-$oc-teal-9: map-get($oc-teal-list, "9");
+$oc-teal-0: map.get($oc-teal-list, "0");
+$oc-teal-1: map.get($oc-teal-list, "1");
+$oc-teal-2: map.get($oc-teal-list, "2");
+$oc-teal-3: map.get($oc-teal-list, "3");
+$oc-teal-4: map.get($oc-teal-list, "4");
+$oc-teal-5: map.get($oc-teal-list, "5");
+$oc-teal-6: map.get($oc-teal-list, "6");
+$oc-teal-7: map.get($oc-teal-list, "7");
+$oc-teal-8: map.get($oc-teal-list, "8");
+$oc-teal-9: map.get($oc-teal-list, "9");
 
 //  Green
 //  ───────────────────────────────────
@@ -274,16 +274,16 @@ $oc-green-list: (
   "9": #2b8a3e,
 );
 
-$oc-green-0: map-get($oc-green-list, "0");
-$oc-green-1: map-get($oc-green-list, "1");
-$oc-green-2: map-get($oc-green-list, "2");
-$oc-green-3: map-get($oc-green-list, "3");
-$oc-green-4: map-get($oc-green-list, "4");
-$oc-green-5: map-get($oc-green-list, "5");
-$oc-green-6: map-get($oc-green-list, "6");
-$oc-green-7: map-get($oc-green-list, "7");
-$oc-green-8: map-get($oc-green-list, "8");
-$oc-green-9: map-get($oc-green-list, "9");
+$oc-green-0: map.get($oc-green-list, "0");
+$oc-green-1: map.get($oc-green-list, "1");
+$oc-green-2: map.get($oc-green-list, "2");
+$oc-green-3: map.get($oc-green-list, "3");
+$oc-green-4: map.get($oc-green-list, "4");
+$oc-green-5: map.get($oc-green-list, "5");
+$oc-green-6: map.get($oc-green-list, "6");
+$oc-green-7: map.get($oc-green-list, "7");
+$oc-green-8: map.get($oc-green-list, "8");
+$oc-green-9: map.get($oc-green-list, "9");
 
 //  Lime
 //  ───────────────────────────────────
@@ -301,16 +301,16 @@ $oc-lime-list: (
   "9": #5c940d,
 );
 
-$oc-lime-0: map-get($oc-lime-list, "0");
-$oc-lime-1: map-get($oc-lime-list, "1");
-$oc-lime-2: map-get($oc-lime-list, "2");
-$oc-lime-3: map-get($oc-lime-list, "3");
-$oc-lime-4: map-get($oc-lime-list, "4");
-$oc-lime-5: map-get($oc-lime-list, "5");
-$oc-lime-6: map-get($oc-lime-list, "6");
-$oc-lime-7: map-get($oc-lime-list, "7");
-$oc-lime-8: map-get($oc-lime-list, "8");
-$oc-lime-9: map-get($oc-lime-list, "9");
+$oc-lime-0: map.get($oc-lime-list, "0");
+$oc-lime-1: map.get($oc-lime-list, "1");
+$oc-lime-2: map.get($oc-lime-list, "2");
+$oc-lime-3: map.get($oc-lime-list, "3");
+$oc-lime-4: map.get($oc-lime-list, "4");
+$oc-lime-5: map.get($oc-lime-list, "5");
+$oc-lime-6: map.get($oc-lime-list, "6");
+$oc-lime-7: map.get($oc-lime-list, "7");
+$oc-lime-8: map.get($oc-lime-list, "8");
+$oc-lime-9: map.get($oc-lime-list, "9");
 
 //  Yellow
 //  ───────────────────────────────────
@@ -328,16 +328,16 @@ $oc-yellow-list: (
   "9": #e67700,
 );
 
-$oc-yellow-0: map-get($oc-yellow-list, "0");
-$oc-yellow-1: map-get($oc-yellow-list, "1");
-$oc-yellow-2: map-get($oc-yellow-list, "2");
-$oc-yellow-3: map-get($oc-yellow-list, "3");
-$oc-yellow-4: map-get($oc-yellow-list, "4");
-$oc-yellow-5: map-get($oc-yellow-list, "5");
-$oc-yellow-6: map-get($oc-yellow-list, "6");
-$oc-yellow-7: map-get($oc-yellow-list, "7");
-$oc-yellow-8: map-get($oc-yellow-list, "8");
-$oc-yellow-9: map-get($oc-yellow-list, "9");
+$oc-yellow-0: map.get($oc-yellow-list, "0");
+$oc-yellow-1: map.get($oc-yellow-list, "1");
+$oc-yellow-2: map.get($oc-yellow-list, "2");
+$oc-yellow-3: map.get($oc-yellow-list, "3");
+$oc-yellow-4: map.get($oc-yellow-list, "4");
+$oc-yellow-5: map.get($oc-yellow-list, "5");
+$oc-yellow-6: map.get($oc-yellow-list, "6");
+$oc-yellow-7: map.get($oc-yellow-list, "7");
+$oc-yellow-8: map.get($oc-yellow-list, "8");
+$oc-yellow-9: map.get($oc-yellow-list, "9");
 
 //  Orange
 //  ───────────────────────────────────
@@ -355,16 +355,16 @@ $oc-orange-list: (
   "9": #d9480f,
 );
 
-$oc-orange-0: map-get($oc-orange-list, "0");
-$oc-orange-1: map-get($oc-orange-list, "1");
-$oc-orange-2: map-get($oc-orange-list, "2");
-$oc-orange-3: map-get($oc-orange-list, "3");
-$oc-orange-4: map-get($oc-orange-list, "4");
-$oc-orange-5: map-get($oc-orange-list, "5");
-$oc-orange-6: map-get($oc-orange-list, "6");
-$oc-orange-7: map-get($oc-orange-list, "7");
-$oc-orange-8: map-get($oc-orange-list, "8");
-$oc-orange-9: map-get($oc-orange-list, "9");
+$oc-orange-0: map.get($oc-orange-list, "0");
+$oc-orange-1: map.get($oc-orange-list, "1");
+$oc-orange-2: map.get($oc-orange-list, "2");
+$oc-orange-3: map.get($oc-orange-list, "3");
+$oc-orange-4: map.get($oc-orange-list, "4");
+$oc-orange-5: map.get($oc-orange-list, "5");
+$oc-orange-6: map.get($oc-orange-list, "6");
+$oc-orange-7: map.get($oc-orange-list, "7");
+$oc-orange-8: map.get($oc-orange-list, "8");
+$oc-orange-9: map.get($oc-orange-list, "9");
 
 //  Color list
 //  ───────────────────────────────────


### PR DESCRIPTION
Actually resolve the `map-get` deprecation warning that #759 pretended to fix.
