### PR TITLE
ci: ignore GHSA-67mh-4wv8-2f99

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "pnpm": {
     "overrides": {
       "cookie@<0.7.0": ">=0.7.0"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-67mh-4wv8-2f99"
+      ]
     }
   }
 }


### PR DESCRIPTION
This vulnerability (GHSA-67mh-4wv8-2f99) only affects users of [esbuild's own built-in dev server](https://esbuild.github.io/api/#serve), not vite's dev server which this project uses.

NB: Vite is our only dependency that depends on esbuild:

<details>
<summary><code>pnpm why -r esbuild</code></summary>

```
Legend: production dependency, optional only, dev only

/home/ppvg/code/minvws/nl-rdo-manon/docs (PRIVATE)

devDependencies:
@sveltejs/adapter-static 3.0.8
└─┬ @sveltejs/kit 2.17.2 peer
  ├─┬ @sveltejs/vite-plugin-svelte 5.0.3 peer
  │ ├─┬ @sveltejs/vite-plugin-svelte-inspector 4.0.1
  │ │ └─┬ vite 6.1.0 peer
  │ │   └── esbuild 0.24.2
  │ ├─┬ vite 6.1.0 peer
  │ │ └── esbuild 0.24.2
  │ └─┬ vitefu 1.0.5
  │   └─┬ vite 6.1.0 peer
  │     └── esbuild 0.24.2
  └─┬ vite 6.1.0 peer
    └── esbuild 0.24.2
@sveltejs/kit 2.17.2
├─┬ @sveltejs/vite-plugin-svelte 5.0.3 peer
│ ├─┬ @sveltejs/vite-plugin-svelte-inspector 4.0.1
│ │ └─┬ vite 6.1.0 peer
│ │   └── esbuild 0.24.2
│ ├─┬ vite 6.1.0 peer
│ │ └── esbuild 0.24.2
│ └─┬ vitefu 1.0.5
│   └─┬ vite 6.1.0 peer
│     └── esbuild 0.24.2
└─┬ vite 6.1.0 peer
  └── esbuild 0.24.2
@sveltejs/vite-plugin-svelte 5.0.3
├─┬ @sveltejs/vite-plugin-svelte-inspector 4.0.1
│ └─┬ vite 6.1.0 peer
│   └── esbuild 0.24.2
├─┬ vite 6.1.0 peer
│ └── esbuild 0.24.2
└─┬ vitefu 1.0.5
  └─┬ vite 6.1.0 peer
    └── esbuild 0.24.2
vite 6.1.0
└── esbuild 0.24.2

/home/ppvg/code/minvws/nl-rdo-manon/examples/vite (PRIVATE)

devDependencies:
vite 6.1.0
└── esbuild 0.24.2
```
</details>

...so this PR can be reverted after updating vite to 6.2, which will bump its esbuild dependency to 0.25.