### PR TITLE
ci: update pnpm to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
-  "packageManager": "pnpm@9.6.0",
+  "packageManager": "pnpm@10.4.1",
   "engines": {
-    "pnpm": "^9.0.0"
+    "pnpm": ">=10"
   },
   "scripts": {
     "dev": "pnpm run --dir docs dev",


### PR DESCRIPTION
Update pnpm to v10 via the package.json `packageManager` and `engines` fields.

In a future update we'll be able to remove the `engines` field, as starting with pnpm v10 [manage-package-manager-versions](https://pnpm.io/npmrc#manage-package-manager-versions) is on by default, but I've left it for now to warn pnpm 9 users to update.