### PR TITLE
fix: fix var padding-left in navigation.scss

### DIFF
--- a/manon/navigation.scss
+++ b/manon/navigation.scss
@@ -45,7 +45,7 @@ nav {
         padding-top: var(--navigation-list-item-icon-padding-top);
         padding-right: var(--navigation-list-item-icon-padding-right);
         padding-bottom: var(--navigation-list-item-icon-padding-bottom);
-        padding-left: var(--navigation-list-item-icon-padding-bottom);
+        padding-left: var(--navigation-list-item-icon-padding-left);
         display: var(--navigation-list-item-icon-display);
       }
     }


### PR DESCRIPTION
This PR fixes this issue in `manon/navigation.scss`
Change `--navigation-list-item-icon-padding-bottom` to `--navigation-list-item-icon-padding-left` for `padding-left`