### PR TITLE
fix: replace use of deprecated `word-break: break-word`

### DIFF
--- a/manon/breadcrumb-bar-content-block.scss
+++ b/manon/breadcrumb-bar-content-block.scss
@@ -69,7 +69,8 @@
         }
 
         a {
-          word-break: break-word; /* Break words that won't fit the available space */
+          /* Break words that won't fit the available space */
+          overflow-wrap: anywhere;
           text-decoration: var(
             --breadcrumb-bar-content-block-link-text-decoration
           );

--- a/manon/breadcrumb-bar.scss
+++ b/manon/breadcrumb-bar.scss
@@ -80,8 +80,8 @@
       }
 
       a {
-        word-break: break-word;
         /* Break words that won't fit the available space */
+        overflow-wrap: anywhere;
         white-space: var(--breadcrumb-bar-link-white-space);
         padding-right: var(--breadcrumb-bar-link-padding-right);
         padding-left: var(--breadcrumb-bar-link-padding-left);

--- a/manon/code-base-variables.scss
+++ b/manon/code-base-variables.scss
@@ -14,8 +14,10 @@
   --code-base-font-size: inherit;
   /* --code-base-width: ; */
   /* --code-base-word-break: ; */
+  /* --code-base-overflow-wrap: ; */
+  /* --code-base-padding*/
 
   /* After breakpoint */
   /* --code-base-breakpoint-word-break: ; */
-  /*--code-base-padding*/
+  /* --code-base-breakpoint-overflow-wrap: ; */
 }

--- a/manon/code-base.scss
+++ b/manon/code-base.scss
@@ -10,11 +10,13 @@ $breakpoint: 24rem !default;
   color: var(--code-base-text-color, inherit);
   width: 100%;
   word-break: var(--code-base-word-break, inherit);
+  overflow-wrap: var(--code-base-overflow-wrap, inherit);
   padding: var(--code-base-padding, 0);
   box-sizing: border-box;
 
   @media (width >= $breakpoint) {
-    word-break: var(--code-base-breakpoint-word-break, break-word);
+    word-break: var(--code-base-breakpoint-word-break, normal);
+    overflow-wrap: var(--code-base-breakpoint-overflow-wrap, anywhere);
   }
 }
 

--- a/manon/description-list.scss
+++ b/manon/description-list.scss
@@ -29,7 +29,7 @@ $breakpoint: 24rem !default;
   dt,
   dd {
     white-space: var(--description-list-item-white-space);
-    word-break: break-word;
+    overflow-wrap: anywhere;
     box-sizing: border-box;
     margin: 0;
   }

--- a/manon/link.scss
+++ b/manon/link.scss
@@ -7,9 +7,8 @@
 
 a {
   cursor: pointer;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   word-wrap: break-word;
-  word-break: break-word;
 
   @include link.link("link-");
   @include link.link-elements-styling("link-");


### PR DESCRIPTION
Use `overflow-wrap: anywhere` instead of the now-deprecated `word-break: break-word`. See [`bread-word` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#break-word).

Unblocks #816.
