### PR TITLE
Refactor Hero component and variables to use theme variables

### DIFF
--- a/docs/src/scss/main.scss
+++ b/docs/src/scss/main.scss
@@ -31,6 +31,7 @@
 @use "@minvws/manon/components/header";
 @use "@minvws/manon/components/header-navigation";
 @use "@minvws/manon/components/heading";
+@use "@minvws/manon/components/hero";
 @use "@minvws/manon/components/horizontal";
 @use "@minvws/manon/components/max-line-length";
 @use "@minvws/manon/components/message-counter";

--- a/manon/components/hero.scss
+++ b/manon/components/hero.scss
@@ -1,0 +1,48 @@
+@use "../mixin/apply-from-theme";
+@use "../variables" as theme;
+
+.hero {
+  display: flex;
+  width: 100%;
+  position: relative;
+  padding: 0;
+
+  @include apply-from-theme.apply-from-theme(
+    (
+      background-color: theme.$hero-background-color,
+      min-height: theme.$hero-min-height,
+      height: theme.$hero-height,
+      max-height: theme.$hero-max-height,
+    )
+  );
+
+  img {
+    object-fit: cover;
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    z-index: 0;
+    @include apply-from-theme.apply-from-theme(
+      (
+        object-position: theme.$hero-image-object-position,
+      )
+    );
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @include apply-from-theme.apply-from-theme(
+      (
+        font-size: theme.$hero-title-font-size,
+        color: theme.$hero-title-text-color,
+      )
+    );
+  }
+}

--- a/manon/variables/_hero.scss
+++ b/manon/variables/_hero.scss
@@ -1,0 +1,7 @@
+$hero-background-color: null !default;
+$hero-min-height: null !default;
+$hero-height: null !default;
+$hero-max-height: null !default;
+$hero-image-object-position: null !default;
+$hero-title-font-size: null !default;
+$hero-title-text-color: null !default;

--- a/manon/variables/_index.scss
+++ b/manon/variables/_index.scss
@@ -15,6 +15,7 @@
 @forward "header";
 @forward "header-navigation";
 @forward "heading";
+@forward "hero";
 @forward "horizontal";
 @forward "max-line-length";
 @forward "message-counter";


### PR DESCRIPTION
Base branch: [feat/manon-sass](https://github.com/minvws/nl-rdo-manon/tree/feat/manon-sass)

Theme variables are initiated with `apply-from-theme()` function. All variables that are defined in this function can be replaced by setting theme variables, the defaut is `null !default;`
