### PR TITLE
fix: iframe resize

### DIFF
--- a/docs/src/scss/iframe.scss
+++ b/docs/src/scss/iframe.scss
@@ -1,8 +1,13 @@
 .resize {
     display: flex;
-    
-    iframe {
-        flex-grow: 1;
-        border: 0;
-    }
+    align-items: stretch;
+    width: 100%;
+    margin: 0;
+    resize: both;
+    overflow: hidden;
+
+  iframe {
+    flex-grow: 1;
+    border: 0;
+  }
 }


### PR DESCRIPTION
Restore the `iframe` styling from the old [docs.scss](https://github.com/minvws/nl-rdo-manon/blob/b0d9db4/docs/src/scss/docs.scss).