### PR TITLE
docs: add link tests

### DIFF
--- a/docs/src/lib/currentPage.svelte.ts
+++ b/docs/src/lib/currentPage.svelte.ts
@@ -1,0 +1,19 @@
+import { page } from "$app/state";
+
+export const currentPage = () => {
+  const current = $derived(page.url.href);
+  const unvisited = $derived.by(() => {
+    const url = new URL(page.url);
+    url.searchParams.set("u", (~~(Math.random() * 1e9) + 1e9).toString(16));
+    return url.href;
+  });
+
+  return {
+    get href() {
+      return current;
+    },
+    get hrefUnvisited() {
+      return unvisited;
+    },
+  };
+};

--- a/docs/src/markdown/components/Iframe.svelte
+++ b/docs/src/markdown/components/Iframe.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import type { HTMLIframeAttributes } from "svelte/elements";
+
+  let { src, children, ...rest }: HTMLIframeAttributes = $props();
+  let rebasedSrc = $derived(src && src.startsWith("/") ? `${base}${src}` : src);
+</script>
+
+<iframe src={rebasedSrc} {...rest}>
+  {@render children?.()}
+</iframe>

--- a/docs/src/markdown/layouts/default.svelte
+++ b/docs/src/markdown/layouts/default.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
   export { default as Code } from "$lib/Code.svelte";
   export { default as a } from "../components/A.svelte";
+  export { default as iframe } from "../components/Iframe.svelte";
 </script>
 
 <script lang="ts">

--- a/docs/src/routes/components/link/+page.svelte
+++ b/docs/src/routes/components/link/+page.svelte
@@ -1,5 +1,5 @@
 <script module>
-  export const breadcrumb = "Links";
+  export const breadcrumb = "Link";
 </script>
 
 <script lang="ts">
@@ -9,7 +9,7 @@
 </script>
 
 <svelte:head>
-  <title>Links</title>
+  <title>Link</title>
 </svelte:head>
 
 <main class="sidemenu" id="main-content" tabindex="-1">
@@ -18,12 +18,13 @@
       <li><a href="#introduction">Introductie</a></li>
       <li><a href="#examples">Voorbeelden</a></li>
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
+      <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
   <article class="visually-grouped">
     <div>
       <section id="introduction">
-        <h1>Links</h1>
+        <h1>Link</h1>
 
         <h2>Benodigde stappen:</h2>
         <ol>
@@ -126,7 +127,7 @@
         <Code
           language="css"
           code={`
-@use "@minvws/manon/links";
+@use "@minvws/manon/link";
 `}
         />
       </section>
@@ -158,7 +159,7 @@
                 >
                 <td>transparent</td>
                 <td>-</td>
-                <th rowspan="4" scope="rowgroup">links</th>
+                <th rowspan="4" scope="rowgroup">link</th>
               </tr>
 
               <tr>
@@ -257,6 +258,11 @@
 }
 `}
         />
+      </section>
+
+      <section id="related">
+        <h2>Gerelateerde pagina's</h2>
+        <a href="{base}/components/link/test">Test- en voorbeelden-pagina</a>
       </section>
     </div>
   </article>

--- a/docs/src/routes/components/link/test/+page.md
+++ b/docs/src/routes/components/link/test/+page.md
@@ -1,0 +1,208 @@
+---
+title: Links testpagina
+---
+
+# Link testpagina
+
+<div class="explanation">
+  <span>Toelichting:</span>
+  Elke case heeft twee tests. De eerste heeft onbezochte links, de tweede bezochte.
+</div>
+
+## Link
+
+<div class="resize">
+  <iframe
+    src="/examples/link-unvisited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/link-visited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+## Link met icoon
+
+<div class="resize">
+  <iframe
+    src="/examples/link-icon-unvisited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/link-icon-visited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+## Link met psuedocontent-icoon (DEPRECATED)
+
+<div class="resize">
+  <iframe
+    src="/examples/link-pseudocontent-icon-unvisited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/link-pseudocontent-icon-visited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+## Externe link
+
+<div class="resize">
+  <iframe
+    src="/examples/link-external-unvisited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/link-external-visited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+## Heading link
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-unvisited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-visited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+## Heading link met icoon
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-icon-unvisited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-icon-visited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+## Externe heading link
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-external-unvisited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/heading-link-external-visited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+## Navigation link
+
+<div class="resize">
+  <iframe
+    src="/examples/navigation-link-unvisited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/navigation-link-visited"
+    title="Voorbeeld"
+    height="304px"
+  ></iframe>
+</div>
+
+## Header navigation link
+
+<div class="resize">
+  <iframe
+    src="/examples/header-navigation-link-unvisited"
+    title="Voorbeeld"
+    height="240px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/header-navigation-link-visited"
+    title="Voorbeeld"
+    height="240px"
+  ></iframe>
+</div>
+
+## Footer link
+
+<div class="resize">
+  <iframe
+    src="/examples/footer-link-unvisited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/footer-link-visited"
+    title="Voorbeeld"
+    height="144px"
+  ></iframe>
+</div>
+
+## Footer navigation link
+
+<div class="resize">
+  <iframe
+    src="/examples/footer-navigation-link-unvisited"
+    title="Voorbeeld"
+    height="288px"
+  ></iframe>
+</div>
+
+<div class="resize">
+  <iframe
+    src="/examples/footer-navigation-link-visited"
+    title="Voorbeeld"
+    height="288px"
+  ></iframe>
+</div>

--- a/docs/src/routes/examples/footer-link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/footer-link-unvisited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<footer>
+  <p>
+    Bezoek <a href={current.hrefUnvisited}>Link</a>,
+    <a href={current.hrefUnvisited} class="focus">Focus</a>,
+    <a href={current.hrefUnvisited} class="hover">Hover</a>,
+    <a href={current.hrefUnvisited} class="active">Active</a>,
+    <a href={current.hrefUnvisited} class="focus hover">Focus Hover</a> of
+    <a href={current.hrefUnvisited} class="focus active">Focus Active</a>.
+  </p>
+</footer>

--- a/docs/src/routes/examples/footer-link-visited/+page.svelte
+++ b/docs/src/routes/examples/footer-link-visited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<footer>
+  <p>
+    Beoek <a href={current.href} class="visited">Link</a>,
+    <a href={current.href} class="visited focus">Focus</a>,
+    <a href={current.href} class="visited hover">Hover</a>,
+    <a href={current.href} class="visited active">Active</a>,
+    <a href={current.href} class="visited focus hover">Focus Hover</a> of
+    <a href={current.href} class="visited focus active">Focus Active</a>.
+  </p>
+</footer>

--- a/docs/src/routes/examples/footer-navigation-link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/footer-navigation-link-unvisited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<footer>
+  <nav>
+      <ul>
+        <li><a href={current.hrefUnvisited}>Link</a></li>
+        <li><a href={current.hrefUnvisited} class="focus">Focus</a></li>
+        <li><a href={current.hrefUnvisited} class="hover">Hover</a></li>
+        <li><a href={current.hrefUnvisited} class="active">Active</a></li>
+        <li><a href={current.hrefUnvisited} class="focus hover">Focus Hover</a></li>
+        <li><a href={current.hrefUnvisited} class="focus active">Focus Active</a></li>
+      </ul>
+  </nav>
+</footer>

--- a/docs/src/routes/examples/footer-navigation-link-visited/+page.svelte
+++ b/docs/src/routes/examples/footer-navigation-link-visited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<footer>
+  <nav>
+    <ul>
+      <li><a href={current.href} class="visited">Link</a></li>
+      <li><a href={current.href} class="visited focus">Focus</a></li>
+      <li><a href={current.href} class="visited hover">Hover</a></li>
+      <li><a href={current.href} class="visited active">Active</a></li>
+      <li><a href={current.href} class="visited focus hover">Focus Hover</a></li>
+      <li><a href={current.href} class="visited focus active">Focus Active</a></li>
+    </ul>
+  </nav>
+</footer>

--- a/docs/src/routes/examples/header-navigation-link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-link-unvisited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<header>
+  <nav>
+    <ul>
+      <li><a href={current.hrefUnvisited}>Link</a></li>
+      <li><a href={current.hrefUnvisited} class="focus">Focus</a></li>
+      <li><a href={current.hrefUnvisited} class="hover">Hover</a></li>
+      <li><a href={current.hrefUnvisited} class="active">Active</a></li>
+      <li><a href={current.hrefUnvisited} class="focus hover">Focus Hover</a></li>
+      <li><a href={current.hrefUnvisited} class="focus active">Focus Active</a></li>
+    </ul>
+  </nav>
+</header>

--- a/docs/src/routes/examples/header-navigation-link-visited/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-link-visited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<header>
+  <nav>
+    <ul>
+      <li><a href={current.href} class="visited">Link</a></li>
+      <li><a href={current.href} class="visited focus">Focus</a></li>
+      <li><a href={current.href} class="visited hover">Hover</a></li>
+      <li><a href={current.href} class="visited active">Active</a></li>
+      <li><a href={current.href} class="visited focus hover">Focus Hover</a></li>
+      <li><a href={current.href} class="visited focus active">Focus Active</a></li>
+    </ul>
+  </nav>
+</header>

--- a/docs/src/routes/examples/header-navigation-with-content-wrapper/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-content-wrapper/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation-with-form-button/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-form-button/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation-with-logo-above/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-logo-above/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation-with-logo/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-logo/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation-with-multiple-menus/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-multiple-menus/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation-with-search/+page.svelte
+++ b/docs/src/routes/examples/header-navigation-with-search/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/header-navigation/+page.svelte
+++ b/docs/src/routes/examples/header-navigation/+page.svelte
@@ -1,5 +1,8 @@
 <script>
   import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import { initCollapsible } from "$lib/manon";
+  onMount(initCollapsible);
 </script>
 
 <header>

--- a/docs/src/routes/examples/heading-link-external-unvisited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-external-unvisited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1><a href={current.hrefUnvisited} rel="external">Link</a></h1>
+    <h2><a href={current.hrefUnvisited} class="focus" rel="external">Focus</a></h2>
+    <h3><a href={current.hrefUnvisited} class="hover" rel="external">Hover</a></h3>
+    <h4><a href={current.hrefUnvisited} class="active" rel="external">Active</a></h4>
+    <h5><a href={current.hrefUnvisited} class="focus hover" rel="external">Focus Hover</a></h5>
+    <h6><a href={current.hrefUnvisited} class="focus active" rel="external">Focus Active</a></h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/heading-link-external-visited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-external-visited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1><a href={current.href} class="visited" rel="external">Link</a></h1>
+    <h2><a href={current.href} class="visited focus" rel="external">Focus</a></h2>
+    <h3><a href={current.href} class="visited hover" rel="external">Hover</a></h3>
+    <h4><a href={current.href} class="visited active" rel="external">Active</a></h4>
+    <h5><a href={current.href} class="visited focus hover" rel="external">Focus Hover</a></h5>
+    <h6><a href={current.href} class="visited focus active" rel="external">Focus Active</a></h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/heading-link-icon-unvisited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-icon-unvisited/+page.svelte
@@ -1,0 +1,45 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1>
+      <a href={current.hrefUnvisited}>
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Link
+      </a>
+    </h1>
+    <h2>
+      <a href={current.hrefUnvisited} class="focus">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus
+      </a>
+    </h2>
+    <h3>
+      <a href={current.hrefUnvisited} class="hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Hover
+      </a>
+    </h3>
+    <h4>
+      <a href={current.hrefUnvisited} class="active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Active
+      </a>
+    </h4>
+    <h5>
+      <a href={current.hrefUnvisited} class="focus hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Hover
+      </a>
+    </h5>
+    <h6>
+      <a href={current.hrefUnvisited} class="focus active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Active
+      </a>
+    </h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/heading-link-icon-visited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-icon-visited/+page.svelte
@@ -1,0 +1,45 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1>
+      <a href={current.href} class="visited">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Link
+      </a>
+    </h1>
+    <h2>
+      <a href={current.href} class="visited focus">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus
+      </a>
+    </h2>
+    <h3>
+      <a href={current.href} class="visited hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Hover
+      </a>
+    </h3>
+    <h4>
+      <a href={current.href} class="visited active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Active
+      </a>
+    </h4>
+    <h5>
+      <a href={current.href} class="visited focus hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Hover
+      </a>
+    </h5>
+    <h6>
+      <a href={current.href} class="visited focus active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Active
+      </a>
+    </h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/heading-link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-unvisited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1><a href={current.hrefUnvisited}>Link</a></h1>
+    <h2><a href={current.hrefUnvisited} class="focus">Focus</a></h2>
+    <h3><a href={current.hrefUnvisited} class="hover">Hover</a></h3>
+    <h4><a href={current.hrefUnvisited} class="active">Active</a></h4>
+    <h5><a href={current.hrefUnvisited} class="focus hover">Focus Hover</a></h5>
+    <h6><a href={current.hrefUnvisited} class="focus active">Focus Active</a></h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/heading-link-visited/+page.svelte
+++ b/docs/src/routes/examples/heading-link-visited/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <h1><a href={current.href} class="visited">Link</a></h1>
+    <h2><a href={current.href} class="visited focus">Focus</a></h2>
+    <h3><a href={current.href} class="visited hover">Hover</a></h3>
+    <h4><a href={current.href} class="visited active">Active</a></h4>
+    <h5><a href={current.href} class="visited focus hover">Focus Hover</a></h5>
+    <h6><a href={current.href} class="visited focus active">Focus Active</a></h6>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-external-unvisited/+page.svelte
+++ b/docs/src/routes/examples/link-external-unvisited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.hrefUnvisited} rel="external">Link</a>,
+      <a href={current.hrefUnvisited} class="focus" rel="external">Focus</a>,
+      <a href={current.hrefUnvisited} class="hover" rel="external">Hover</a>,
+      <a href={current.hrefUnvisited} class="active" rel="external">Active</a>,
+      <a href={current.hrefUnvisited} class="focus hover" rel="external">Focus Hover</a> of
+      <a href={current.hrefUnvisited} class="focus active" rel="external">Focus Active</a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-external-visited/+page.svelte
+++ b/docs/src/routes/examples/link-external-visited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.href} class="visited" rel="external">Link</a>,
+      <a href={current.href} class="visited focus" rel="external">Focus</a>,
+      <a href={current.href} class="visited hover" rel="external">Hover</a>,
+      <a href={current.href} class="visited active" rel="external">Active</a>,
+      <a href={current.href} class="visited focus hover" rel="external">Focus Hover</a>
+      of <a href={current.href} class="visited focus active" rel="external">Focus Active</a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-icon-unvisited/+page.svelte
+++ b/docs/src/routes/examples/link-icon-unvisited/+page.svelte
@@ -1,0 +1,36 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.hrefUnvisited}>
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Link
+      </a>,
+      <a href={current.hrefUnvisited} class="focus">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus
+      </a>,
+      <a href={current.hrefUnvisited} class="hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Hover
+      </a>,
+      <a href={current.hrefUnvisited} class="active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Active
+      </a>,
+      <a href={current.hrefUnvisited} class="focus hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Hover
+      </a>
+      of
+      <a href={current.hrefUnvisited} class="focus active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Active
+      </a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-icon-visited/+page.svelte
+++ b/docs/src/routes/examples/link-icon-visited/+page.svelte
@@ -1,0 +1,36 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.href} class="visited">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Link
+      </a>,
+      <a href={current.href} class="visited focus">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus
+      </a>,
+      <a href={current.href} class="visited hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Hover
+      </a>,
+      <a href={current.href} class="visited active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Active
+      </a>,
+      <a href={current.href} class="visited focus hover">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Hover
+      </a>
+      of
+      <a href={current.href} class="visited focus active">
+        <span class="icon icon-heart" aria-hidden="true"></span>
+        Focus Active
+      </a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-pseudocontent-icon-unvisited/+page.svelte
+++ b/docs/src/routes/examples/link-pseudocontent-icon-unvisited/+page.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.hrefUnvisited} class="icon icon-heart">Link</a>,
+      <a href={current.hrefUnvisited} class="focus icon icon-heart">Focus</a>,
+      <a href={current.hrefUnvisited} class="hover icon icon-heart">Hover</a>,
+      <a href={current.hrefUnvisited} class="active icon icon-heart">Active</a>,
+      <a href={current.hrefUnvisited} class="focus hover icon icon-heart">Focus Hover</a>
+      of
+      <a href={current.hrefUnvisited} class="focus active icon icon-heart">Focus Active</a>.
+    </p>
+  </section>
+</main>
+
+<style>
+  main {
+    text-decoration: line-through;
+  }
+</style>

--- a/docs/src/routes/examples/link-pseudocontent-icon-visited/+page.svelte
+++ b/docs/src/routes/examples/link-pseudocontent-icon-visited/+page.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.href} class="visited icon icon-heart">Link</a>,
+      <a href={current.href} class="visited focus icon icon-heart">Focus</a>,
+      <a href={current.href} class="visited hover icon icon-heart">Hover</a>,
+      <a href={current.href} class="visited active icon icon-heart">Active</a>,
+      <a href={current.href} class="visited focus hover icon icon-heart">Focus Hover</a>
+      of
+      <a href={current.href} class="visited focus active icon icon-heart">Focus Active</a>.
+    </p>
+  </section>
+</main>
+
+<style>
+  main {
+    text-decoration: line-through;
+  }
+</style>

--- a/docs/src/routes/examples/link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/link-unvisited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.hrefUnvisited}>Link</a>,
+      <a href={current.hrefUnvisited} class="focus">Focus</a>,
+      <a href={current.hrefUnvisited} class="hover">Hover</a>,
+      <a href={current.hrefUnvisited} class="active">Active</a>,
+      <a href={current.hrefUnvisited} class="focus hover">Focus Hover</a> of
+      <a href={current.hrefUnvisited} class="focus active">Focus Active</a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/link-visited/+page.svelte
+++ b/docs/src/routes/examples/link-visited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <section class="visually-grouped">
+    <p>
+      Bezoek <a href={current.href} class="visited">Link</a>,
+      <a href={current.href} class="visited focus">Focus</a>,
+      <a href={current.href} class="visited hover">Hover</a>,
+      <a href={current.href} class="visited active">Active</a>,
+      <a href={current.href} class="visited focus hover">Focus Hover</a>
+      of <a href={current.href} class="visited focus active">Focus Active</a>.
+    </p>
+  </section>
+</main>

--- a/docs/src/routes/examples/navigation-link-unvisited/+page.svelte
+++ b/docs/src/routes/examples/navigation-link-unvisited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <nav>
+    <ul>
+      <li><a href={current.hrefUnvisited}>Link</a></li>
+      <li><a href={current.hrefUnvisited} class="focus">Focus</a></li>
+      <li><a href={current.hrefUnvisited} class="hover">Hover</a></li>
+      <li><a href={current.hrefUnvisited} class="active">Active</a></li>
+      <li><a href={current.hrefUnvisited} class="focus hover">Focus Hover</a></li>
+      <li><a href={current.hrefUnvisited} class="focus active">Focus Active</a></li>
+    </ul>
+  </nav>
+</main>

--- a/docs/src/routes/examples/navigation-link-visited/+page.svelte
+++ b/docs/src/routes/examples/navigation-link-visited/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { currentPage } from "$lib/currentPage.svelte";
+  const current = currentPage();
+</script>
+
+<main>
+  <nav>
+    <ul>
+      <li><a href={current.href} class="visited">Link</a></li>
+      <li><a href={current.href} class="visited focus">Focus</a></li>
+      <li><a href={current.href} class="visited hover">Hover</a></li>
+      <li><a href={current.href} class="visited active">Active</a></li>
+      <li><a href={current.href} class="visited focus hover">Focus Hover</a></li>
+      <li><a href={current.href} class="visited focus active">Focus Active</a></li>
+    </ul>
+  </nav>
+</main>


### PR DESCRIPTION
Add link tests page. Also renames the "Links" page to "Link" for consistency with the URL and the manon module name, but does not attempt to improve the Link page otherwise.

**NB**: this test page displays visual bugs which #817 attempted to correct.

<details>
<summary>Screenshot of test page.</summary>

![Screenshot](https://github.com/user-attachments/assets/95623402-b48e-4dbe-aba4-d21a42f2f19e)
</details>

Extracted from #817. 