### PR TITLE
fix: Remove visually grouped

### DIFF
--- a/docs/src/markdown/layouts/default.svelte
+++ b/docs/src/markdown/layouts/default.svelte
@@ -35,7 +35,7 @@
   {#if parsedNav}
     <SideMenu>{@render navlist(parsedNav)}</SideMenu>
   {/if}
-  <section class="visually-grouped">
+  <section>
     {@render children?.()}
   </section>
 </main>

--- a/docs/src/routes/components/+page.svelte
+++ b/docs/src/routes/components/+page.svelte
@@ -18,7 +18,7 @@
     </div>
   </section>
 
-  <section id="base-styling" class="visually-grouped">
+  <section id="base-styling">
     <h2>Basisopmaak</h2>
     <div class="column-2">
       <nav aria-labelledby="layout-text-heading">
@@ -45,7 +45,7 @@
     </div>
   </section>
 
-  <section id="layout" class="visually-grouped">
+  <section id="layout">
     <h2>Layout</h2>
     <div class="column-2">
       <nav aria-labelledby="layout-base">
@@ -62,7 +62,7 @@
     </div>
   </section>
 
-  <section id="components" class="visually-grouped">
+  <section id="components">
     <h2>Componenten</h2>
 
     <div class="column-2">
@@ -111,7 +111,7 @@
     </div>
   </section>
 
-  <section id="other" class="visually-grouped">
+  <section id="other">
     <h2 id="other-heading">Overig</h2>
     <p class="warning">
       Let op: de documentatie over deze componenten is waarschijnlijk onvolledig of incorrect.

--- a/docs/src/routes/components/accordion/+page.svelte
+++ b/docs/src/routes/components/accordion/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Accordeon</h1>

--- a/docs/src/routes/components/article-content-wrapper-test/+page.svelte
+++ b/docs/src/routes/components/article-content-wrapper-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Article content wrapper</h1>
       <p>Componenten gegroepeerd in <code>article</code>'s.</p>
@@ -22,7 +22,7 @@
         language="html"
         code={`
 <main>
-  <article class="visually-grouped"> <!-- This can be full width -->
+  <article> <!-- This can be full width -->
     <div> <!-- While the content width can be limited -->
       <!-- content -->
     </div>

--- a/docs/src/routes/components/article-content-wrapper/+page.svelte
+++ b/docs/src/routes/components/article-content-wrapper/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Article content wrapper</h1>
@@ -62,7 +62,7 @@
         <Code
           language="html"
           code={`
-<article class="visually-grouped">
+<article>
   <div> <!-- Content wrapper -->
     <!-- Content -->
   <div>

--- a/docs/src/routes/components/article-test/+page.svelte
+++ b/docs/src/routes/components/article-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <h1>article</h1>
     <p>Componenten gegroepeerd in <code>article</code>'s.</p>
 
@@ -21,7 +21,7 @@
       language="html"
       code={`
 <main>
-  <article class="visually-grouped">
+  <article>
     <!-- Content -->
   </article>
 </main>
@@ -29,7 +29,7 @@
     />
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Gebruikte componenten</h2>
     <p>
       Voor meer informatie over importeren en instellen van componenten. Zie: <a
@@ -49,7 +49,7 @@
     />
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h3>Ingestelde waarden</h3>
     <h4>CSS-voorbeeld</h4>
     <Code

--- a/docs/src/routes/components/article/+page.svelte
+++ b/docs/src/routes/components/article/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Artikel - <code>article</code></h1>
@@ -62,7 +62,7 @@
         <Code
           language="html"
           code={`
-<article class="visually-grouped">
+<article>
   <!-- Content -->
 </article>
 `}

--- a/docs/src/routes/components/body-text-set/+page.svelte
+++ b/docs/src/routes/components/body-text-set/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Body text set</h1>

--- a/docs/src/routes/components/branding-colors/+page.svelte
+++ b/docs/src/routes/components/branding-colors/+page.svelte
@@ -17,7 +17,7 @@
       <li><a href="#introduction">Introductie</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Kleurensets</h1>

--- a/docs/src/routes/components/breadcrumb-bar/+page.svelte
+++ b/docs/src/routes/components/breadcrumb-bar/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Kruimelpad - breadcrumb-bar</h1>

--- a/docs/src/routes/components/button-container-test/+page.svelte
+++ b/docs/src/routes/components/button-container-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Subtielere weergave testpagina</h1>

--- a/docs/src/routes/components/button-destructive-test/+page.svelte
+++ b/docs/src/routes/components/button-destructive-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article id="button-base" class="visually-grouped">
+  <article id="button-base">
     <div>
       <section id="introduction">
         <h1>"Destructieve testpagina</h1>

--- a/docs/src/routes/components/button-destructive/+page.svelte
+++ b/docs/src/routes/components/button-destructive/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article id="button-base" class="visually-grouped">
+  <article id="button-base">
     <div>
       <section id="introduction">
         <h1>Destructieve knop</h1>

--- a/docs/src/routes/components/button-ghost-test/+page.svelte
+++ b/docs/src/routes/components/button-ghost-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article id="button-base" class="visually-grouped">
+  <article id="button-base">
     <div>
       <section id="introduction">
         <h1>"Ghost button" testpagina</h1>

--- a/docs/src/routes/components/button-ghost/+page.svelte
+++ b/docs/src/routes/components/button-ghost/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article id="button-ghost" class="visually-grouped">
+  <article id="button-ghost">
     <div>
       <section id="introduction">
         <h1>Ghost button</h1>

--- a/docs/src/routes/components/button-icon-only/+page.svelte
+++ b/docs/src/routes/components/button-icon-only/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article id="button-base" class="visually-grouped">
+  <article id="button-base">
     <div>
       <section id="introduction">
         <h1>Icoonknoppen zonder achtergrond</h1>
@@ -34,7 +34,9 @@
             van een icoonknop zonder achtergrond.
           </li>
           <li>
-            Voeg een icoon toe aan de knop. Zie voor meer informatie: <a href="{base}/components/button/icon">Icoonknop</a>.
+            Voeg een icoon toe aan de knop. Zie voor meer informatie: <a
+              href="{base}/components/button/icon">Icoonknop</a
+            >.
           </li>
         </ol>
 

--- a/docs/src/routes/components/button-test/+page.svelte
+++ b/docs/src/routes/components/button-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article id="button-base" class="visually-grouped">
+  <article id="button-base">
     <div>
       <section id="introduction">
         <h1>Knoppen testpagina</h1>

--- a/docs/src/routes/components/button-to-top/+page.svelte
+++ b/docs/src/routes/components/button-to-top/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Terug naar hoofdmenu knop</h1>

--- a/docs/src/routes/components/card/+page.svelte
+++ b/docs/src/routes/components/card/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Kaart</h1>

--- a/docs/src/routes/components/checkbox-test/+page.svelte
+++ b/docs/src/routes/components/checkbox-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Selectievak testpagina</h1>

--- a/docs/src/routes/components/checkbox/+page.svelte
+++ b/docs/src/routes/components/checkbox/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Selectievak - <code>checkbox</code></h1>

--- a/docs/src/routes/components/collapsible-menu/+page.svelte
+++ b/docs/src/routes/components/collapsible-menu/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Inklapbaar menu</h1>

--- a/docs/src/routes/components/collapsible/+page.svelte
+++ b/docs/src/routes/components/collapsible/+page.svelte
@@ -24,7 +24,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Inklapbaar component</h1>

--- a/docs/src/routes/components/de-emphasized-test/+page.svelte
+++ b/docs/src/routes/components/de-emphasized-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Subtielere weergave testpagina</h1>

--- a/docs/src/routes/components/de-emphasized/+page.svelte
+++ b/docs/src/routes/components/de-emphasized/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Subtielere weergave</h1>

--- a/docs/src/routes/components/description-list/+page.svelte
+++ b/docs/src/routes/components/description-list/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Description list</h1>
 

--- a/docs/src/routes/components/div-content-wrapper/+page.svelte
+++ b/docs/src/routes/components/div-content-wrapper/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Div content wrapper</h1>

--- a/docs/src/routes/components/div/+page.svelte
+++ b/docs/src/routes/components/div/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1><code>div</code></h1>

--- a/docs/src/routes/components/emphasized-test/+page.svelte
+++ b/docs/src/routes/components/emphasized-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Benadrukte weergave testpagina</h1>

--- a/docs/src/routes/components/emphasized/+page.svelte
+++ b/docs/src/routes/components/emphasized/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Benadrukte weergave</h1>

--- a/docs/src/routes/components/fieldset-checkbox-test/+page.svelte
+++ b/docs/src/routes/components/fieldset-checkbox-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Fieldset selectievak testpagina</h1>

--- a/docs/src/routes/components/fieldset-checkbox/+page.svelte
+++ b/docs/src/routes/components/fieldset-checkbox/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Selectievak - <code>checkbox</code></h1>

--- a/docs/src/routes/components/fieldset-radio/+page.svelte
+++ b/docs/src/routes/components/fieldset-radio/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Radio-selecteerknop - <code>radio</code></h1>

--- a/docs/src/routes/components/filter-test/+page.svelte
+++ b/docs/src/routes/components/filter-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Filter testpagina</h1>

--- a/docs/src/routes/components/filter/+page.svelte
+++ b/docs/src/routes/components/filter/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Filter</h1>

--- a/docs/src/routes/components/font/+page.svelte
+++ b/docs/src/routes/components/font/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Font</h1>

--- a/docs/src/routes/components/footer/+page.svelte
+++ b/docs/src/routes/components/footer/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Footer</h1>

--- a/docs/src/routes/components/form-accent-color-test/+page.svelte
+++ b/docs/src/routes/components/form-accent-color-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Accentkleur op formulierelementen testpagina</h1>

--- a/docs/src/routes/components/form-accent-color/+page.svelte
+++ b/docs/src/routes/components/form-accent-color/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <p class="warning" role="group" aria-label="waarschuwing">
         <span>Waarschuwing:</span> Dit element maakt gebruik van een nieuw CSS component. Moderne

--- a/docs/src/routes/components/form-base-test/+page.svelte
+++ b/docs/src/routes/components/form-base-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Basisformulier testpagina</h1>

--- a/docs/src/routes/components/form-base/+page.svelte
+++ b/docs/src/routes/components/form-base/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Basisformulier</h1>

--- a/docs/src/routes/components/form-columns-test/+page.svelte
+++ b/docs/src/routes/components/form-columns-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Weergave in kolommen testpagina</h1>

--- a/docs/src/routes/components/form-columns/+page.svelte
+++ b/docs/src/routes/components/form-columns/+page.svelte
@@ -22,7 +22,7 @@
       <li><a href="#issues">Bekende problemen</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Weergave in kolommen</h1>

--- a/docs/src/routes/components/form-combined-fields-test/+page.svelte
+++ b/docs/src/routes/components/form-combined-fields-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Gecombineerde testpagina</h1>

--- a/docs/src/routes/components/form-combined-fields/+page.svelte
+++ b/docs/src/routes/components/form-combined-fields/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Gecombineerde velden</h1>

--- a/docs/src/routes/components/form-fieldset-invisible/+page.svelte
+++ b/docs/src/routes/components/form-fieldset-invisible/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Onzichtbare fieldset</h1>

--- a/docs/src/routes/components/form-fieldset/+page.svelte
+++ b/docs/src/routes/components/form-fieldset/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Fieldset - <code>fieldset</code></h1>

--- a/docs/src/routes/components/form-help-test/+page.svelte
+++ b/docs/src/routes/components/form-help-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Hulpteksten testpagina</h1>

--- a/docs/src/routes/components/form-help/+page.svelte
+++ b/docs/src/routes/components/form-help/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Hulpteksten</h1>

--- a/docs/src/routes/components/form-horizontal-view-test/+page.svelte
+++ b/docs/src/routes/components/form-horizontal-view-test/+page.svelte
@@ -89,7 +89,7 @@
       <li><a href="#button-container">Gegroepeerde buttons</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal uitgelijnde testpagina</h1>

--- a/docs/src/routes/components/form-horizontal-view/+page.svelte
+++ b/docs/src/routes/components/form-horizontal-view/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal uitgelijnd</h1>

--- a/docs/src/routes/components/form-inline-test/+page.svelte
+++ b/docs/src/routes/components/form-inline-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Inlineformulier testpagina</h1>

--- a/docs/src/routes/components/form-inline/+page.svelte
+++ b/docs/src/routes/components/form-inline/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>"inline"-formulier</h1>

--- a/docs/src/routes/components/form-input-color-filled-test/+page.svelte
+++ b/docs/src/routes/components/form-input-color-filled-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Kleurselector volledig gevuld</h1>

--- a/docs/src/routes/components/form-input-color-filled/+page.svelte
+++ b/docs/src/routes/components/form-input-color-filled/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <p class="warning" role="group" aria-label="waarschuwing">
         <span>Waarschuwing:</span> Dit element maakt gebruik van experimentele CSS componenten:

--- a/docs/src/routes/components/form-input-color-test/+page.svelte
+++ b/docs/src/routes/components/form-input-color-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Datum</h1>

--- a/docs/src/routes/components/form-input-color/+page.svelte
+++ b/docs/src/routes/components/form-input-color/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Kleurselector</h1>

--- a/docs/src/routes/components/form-input-date-test/+page.svelte
+++ b/docs/src/routes/components/form-input-date-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Datum</h1>

--- a/docs/src/routes/components/form-input-date/+page.svelte
+++ b/docs/src/routes/components/form-input-date/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Datum</h1>

--- a/docs/src/routes/components/form-input-email-test/+page.svelte
+++ b/docs/src/routes/components/form-input-email-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Email</h1>

--- a/docs/src/routes/components/form-input-email/+page.svelte
+++ b/docs/src/routes/components/form-input-email/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Email</h1>

--- a/docs/src/routes/components/form-input-file-test/+page.svelte
+++ b/docs/src/routes/components/form-input-file-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Bestand testpagina</h1>

--- a/docs/src/routes/components/form-input-file/+page.svelte
+++ b/docs/src/routes/components/form-input-file/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Bestand</h1>

--- a/docs/src/routes/components/form-input-password-test/+page.svelte
+++ b/docs/src/routes/components/form-input-password-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Wachtwoord testpagina</h1>

--- a/docs/src/routes/components/form-input-password/+page.svelte
+++ b/docs/src/routes/components/form-input-password/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Wachtwoord</h1>

--- a/docs/src/routes/components/form-input-radio-test/+page.svelte
+++ b/docs/src/routes/components/form-input-radio-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Radio-selecteerknop - <code>textarea</code> testpagina</h1>

--- a/docs/src/routes/components/form-input-radio/+page.svelte
+++ b/docs/src/routes/components/form-input-radio/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Radio-selecteerknop - <code>radio-button</code></h1>

--- a/docs/src/routes/components/form-input-range-test/+page.svelte
+++ b/docs/src/routes/components/form-input-range-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Bereik - <code>textarea</code> testpagina</h1>

--- a/docs/src/routes/components/form-input-range/+page.svelte
+++ b/docs/src/routes/components/form-input-range/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Bereik - <code>range</code></h1>

--- a/docs/src/routes/components/form-input-test/+page.svelte
+++ b/docs/src/routes/components/form-input-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Invoerveld testpagina</h1>

--- a/docs/src/routes/components/form-input-textarea-test/+page.svelte
+++ b/docs/src/routes/components/form-input-textarea-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tekstveld - <code>textarea</code> testpagina</h1>

--- a/docs/src/routes/components/form-input-textarea/+page.svelte
+++ b/docs/src/routes/components/form-input-textarea/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tekstveld - <code>textarea</code></h1>

--- a/docs/src/routes/components/form-input/+page.svelte
+++ b/docs/src/routes/components/form-input/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Invoerveld</h1>

--- a/docs/src/routes/components/form-notification-test/+page.svelte
+++ b/docs/src/routes/components/form-notification-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notificatie binnen formulier testpagina</h1>

--- a/docs/src/routes/components/form-notification/+page.svelte
+++ b/docs/src/routes/components/form-notification/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notificatie binnen formulier</h1>

--- a/docs/src/routes/components/form-required-test/+page.svelte
+++ b/docs/src/routes/components/form-required-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Invoerveld verplicht testpagina</h1>

--- a/docs/src/routes/components/form-required/+page.svelte
+++ b/docs/src/routes/components/form-required/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Verplichte velden</h1>

--- a/docs/src/routes/components/form-select-test/+page.svelte
+++ b/docs/src/routes/components/form-select-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Selectielijst - <code>select</code> testpagina</h1>

--- a/docs/src/routes/components/form-select/+page.svelte
+++ b/docs/src/routes/components/form-select/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <p class="warning" role="group" aria-label="waarschuwing">
         <span>Waarschuwing:</span> Het <code>select</code>-element wordt binnen browsers en

--- a/docs/src/routes/components/forms/+page.svelte
+++ b/docs/src/routes/components/forms/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Formulieren</h1>

--- a/docs/src/routes/components/header-navigation/+page.svelte
+++ b/docs/src/routes/components/header-navigation/+page.svelte
@@ -31,7 +31,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Header</h1>

--- a/docs/src/routes/components/heading-base-set/+page.svelte
+++ b/docs/src/routes/components/heading-base-set/+page.svelte
@@ -20,13 +20,13 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Titel basisset</h1>
         <p>Basisset voor het stylen van titels.</p>
 
-        <div class="visually-grouped">
+        <div>
           <h2>Benodigde stappen:</h2>
           <ol>
             <li>
@@ -56,7 +56,7 @@
         </div>
       </section>
 
-      <section id="examples" class="visually-grouped">
+      <section id="examples">
         <h2>Voorbeelden</h2>
 
         <h3>Beschikbare opties</h3>
@@ -150,7 +150,7 @@
         />
       </section>
 
-      <section id="requirements" class="visually-grouped">
+      <section id="requirements">
         <h2>Bijbehorende bestanden</h2>
         <p>
           Voor meer informatie over importeren en instellen van componenten. Zie:

--- a/docs/src/routes/components/headings-test/+page.svelte
+++ b/docs/src/routes/components/headings-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Titel testpagina</h1>

--- a/docs/src/routes/components/headings/+page.svelte
+++ b/docs/src/routes/components/headings/+page.svelte
@@ -21,13 +21,13 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Titels</h1>
         <p>Gebruik titels om structuur binnen de pagina aan te geven.</p>
 
-        <div class="visually-grouped">
+        <div>
           <h2 class="heading-normal">Aandachtspunten:</h2>
           <ul>
             <li>Gebruik altijd een <code>h1</code> per pagina.*</li>
@@ -59,7 +59,7 @@
         </div>
       </section>
 
-      <section id="examples" class="visually-grouped">
+      <section id="examples">
         <h2>Voorbeelden:</h2>
         <h3>Visueel voorbeeld:</h3>
 

--- a/docs/src/routes/components/icons/+page.svelte
+++ b/docs/src/routes/components/icons/+page.svelte
@@ -53,7 +53,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Iconen</h1>

--- a/docs/src/routes/components/icons/add-set/+page.svelte
+++ b/docs/src/routes/components/icons/add-set/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Icoon-set toevoegen</h1>

--- a/docs/src/routes/components/icons/test/+page.svelte
+++ b/docs/src/routes/components/icons/test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Iconen testpagina</h1>

--- a/docs/src/routes/components/image-cover-test/+page.svelte
+++ b/docs/src/routes/components/image-cover-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Cover-afbeelding testpagina</h1>

--- a/docs/src/routes/components/image-cover/+page.svelte
+++ b/docs/src/routes/components/image-cover/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Cover-afbeelding</h1>

--- a/docs/src/routes/components/image-icon/+page.svelte
+++ b/docs/src/routes/components/image-icon/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Icoon-afbeelding</h1>

--- a/docs/src/routes/components/image-round-test/+page.svelte
+++ b/docs/src/routes/components/image-round-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Ronde afbeelding testpagina</h1>

--- a/docs/src/routes/components/image-round/+page.svelte
+++ b/docs/src/routes/components/image-round/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Ronde afbeelding</h1>

--- a/docs/src/routes/components/image-square-test/+page.svelte
+++ b/docs/src/routes/components/image-square-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Vierkante afbeelding testpagina</h1>

--- a/docs/src/routes/components/image-square/+page.svelte
+++ b/docs/src/routes/components/image-square/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Vierkante afbeelding</h1>

--- a/docs/src/routes/components/language-selector-test/+page.svelte
+++ b/docs/src/routes/components/language-selector-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Taalselectie testpagina</h1>

--- a/docs/src/routes/components/language-selector/+page.svelte
+++ b/docs/src/routes/components/language-selector/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Taalselectie</h1>

--- a/docs/src/routes/components/layout-authentication-test/+page.svelte
+++ b/docs/src/routes/components/layout-authentication-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout authenticatie testpagina</h1>

--- a/docs/src/routes/components/layout-authentication/+page.svelte
+++ b/docs/src/routes/components/layout-authentication/+page.svelte
@@ -22,7 +22,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout authenticatie</h1>

--- a/docs/src/routes/components/layout-form/+page.svelte
+++ b/docs/src/routes/components/layout-form/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout form</h1>

--- a/docs/src/routes/components/layout-set/+page.svelte
+++ b/docs/src/routes/components/layout-set/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout set</h1>

--- a/docs/src/routes/components/link/+page.svelte
+++ b/docs/src/routes/components/link/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Links</h1>

--- a/docs/src/routes/components/login-meta-test/+page.svelte
+++ b/docs/src/routes/components/login-meta-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Ingelogd als testpagina</h1>

--- a/docs/src/routes/components/login-meta/+page.svelte
+++ b/docs/src/routes/components/login-meta/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Ingelogd als</h1>

--- a/docs/src/routes/components/logo/+page.svelte
+++ b/docs/src/routes/components/logo/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Logo</h1>

--- a/docs/src/routes/components/main-content-wrapper/+page.svelte
+++ b/docs/src/routes/components/main-content-wrapper/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Main content wrapper</h1>

--- a/docs/src/routes/components/main-test/+page.svelte
+++ b/docs/src/routes/components/main-test/+page.svelte
@@ -18,7 +18,7 @@
       <li><a href="#tests">Tests</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Main testpagina</h1>
@@ -78,7 +78,7 @@
           language="html"
           code={`
 <main>
-  <article class="visually-grouped">
+  <article>
     <!-- content -->
   </article>
 </main>

--- a/docs/src/routes/components/main/+page.svelte
+++ b/docs/src/routes/components/main/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Main</h1>

--- a/docs/src/routes/components/max-line-length/+page.svelte
+++ b/docs/src/routes/components/max-line-length/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#variables">Instelbare variabelen</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Maximale regellengte</h1>

--- a/docs/src/routes/components/message-counter/+page.svelte
+++ b/docs/src/routes/components/message-counter/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notificatie-teller</h1>

--- a/docs/src/routes/components/navigation/+page.svelte
+++ b/docs/src/routes/components/navigation/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Navigatie</h1>

--- a/docs/src/routes/components/nota-bene-test/+page.svelte
+++ b/docs/src/routes/components/nota-bene-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Nota bene testpagina</h1>

--- a/docs/src/routes/components/nota-bene/+page.svelte
+++ b/docs/src/routes/components/nota-bene/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Nota bene</h1>

--- a/docs/src/routes/components/notification-confirmation/+page.svelte
+++ b/docs/src/routes/components/notification-confirmation/+page.svelte
@@ -63,7 +63,7 @@
       <li><a href="#requirements">Benodigdheden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Bevestiging</h1>

--- a/docs/src/routes/components/notification-error/+page.svelte
+++ b/docs/src/routes/components/notification-error/+page.svelte
@@ -49,7 +49,7 @@
       <li><a href="#requirements">Benodigdheden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Foutmelding</h1>

--- a/docs/src/routes/components/notification-explanation/+page.svelte
+++ b/docs/src/routes/components/notification-explanation/+page.svelte
@@ -49,7 +49,7 @@
       <li><a href="#requirements">Benodigdheden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Toelichting</h1>

--- a/docs/src/routes/components/notification-system-message/+page.svelte
+++ b/docs/src/routes/components/notification-system-message/+page.svelte
@@ -49,7 +49,7 @@
       <li><a href="#requirements">Benodigdheden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Systeembericht</h1>

--- a/docs/src/routes/components/notification-warning/+page.svelte
+++ b/docs/src/routes/components/notification-warning/+page.svelte
@@ -49,7 +49,7 @@
       <li><a href="#requirements">Benodigdheden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Waarschuwing</h1>

--- a/docs/src/routes/components/notifications-block-element-test/+page.svelte
+++ b/docs/src/routes/components/notifications-block-element-test/+page.svelte
@@ -36,7 +36,7 @@
       </li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h2>Blok-element testpagina</h2>

--- a/docs/src/routes/components/notifications-block-element/+page.svelte
+++ b/docs/src/routes/components/notifications-block-element/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Blok-element</h1>

--- a/docs/src/routes/components/notifications-page-example-confirmation/+page.svelte
+++ b/docs/src/routes/components/notifications-page-example-confirmation/+page.svelte
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie bevestiging voorbeeld</h1>

--- a/docs/src/routes/components/notifications-page-example-error/+page.svelte
+++ b/docs/src/routes/components/notifications-page-example-error/+page.svelte
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie foutmelding voorbeeld</h1>

--- a/docs/src/routes/components/notifications-page-example-explanation/+page.svelte
+++ b/docs/src/routes/components/notifications-page-example-explanation/+page.svelte
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie toelichting voorbeeld</h1>

--- a/docs/src/routes/components/notifications-page-example-system/+page.svelte
+++ b/docs/src/routes/components/notifications-page-example-system/+page.svelte
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie systeembericht voorbeeld</h1>

--- a/docs/src/routes/components/notifications-page-example-warning/+page.svelte
+++ b/docs/src/routes/components/notifications-page-example-warning/+page.svelte
@@ -19,7 +19,7 @@
     </div>
   </section>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie waarschuwing voorbeeld</h1>

--- a/docs/src/routes/components/notifications-page/+page.svelte
+++ b/docs/src/routes/components/notifications-page/+page.svelte
@@ -17,7 +17,7 @@
       <li><a href="#examples">Voorbeelden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Pagina-notificatie</h1>

--- a/docs/src/routes/components/notifications-paragraph-test/+page.svelte
+++ b/docs/src/routes/components/notifications-paragraph-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notifactie op een paragraaf testpagina</h1>

--- a/docs/src/routes/components/notifications-paragraph/+page.svelte
+++ b/docs/src/routes/components/notifications-paragraph/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notifactie op een paragraaf</h1>

--- a/docs/src/routes/components/notifications-table-test/+page.svelte
+++ b/docs/src/routes/components/notifications-table-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notifactie op een paragraaf testpagina</h1>

--- a/docs/src/routes/components/notifications-table/+page.svelte
+++ b/docs/src/routes/components/notifications-table/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notificatie binnen tabellen</h1>

--- a/docs/src/routes/components/notifications/+page.svelte
+++ b/docs/src/routes/components/notifications/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Notificaties</h1>

--- a/docs/src/routes/components/pagination-test/+page.svelte
+++ b/docs/src/routes/components/pagination-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Paginering testpagina</h1>

--- a/docs/src/routes/components/pagination/+page.svelte
+++ b/docs/src/routes/components/pagination/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Paginering</h1>

--- a/docs/src/routes/components/paragraph-test/+page.svelte
+++ b/docs/src/routes/components/paragraph-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Paragraaf testpagina</h1>

--- a/docs/src/routes/components/paragraph/+page.svelte
+++ b/docs/src/routes/components/paragraph/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Paragraaf</h1>

--- a/docs/src/routes/components/section-content-wrapper/+page.svelte
+++ b/docs/src/routes/components/section-content-wrapper/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Sectie content wrapper</h1>

--- a/docs/src/routes/components/section/+page.svelte
+++ b/docs/src/routes/components/section/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Sectie <code>section</code></h1>

--- a/docs/src/routes/components/sidemenu/+page.svelte
+++ b/docs/src/routes/components/sidemenu/+page.svelte
@@ -19,7 +19,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Zijmenu</h1>

--- a/docs/src/routes/components/sidemenu/in-page-collapsible/+page.svelte
+++ b/docs/src/routes/components/sidemenu/in-page-collapsible/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>In- en uitklapbaar zijmenu binnen de pagina</h1>
@@ -104,7 +104,10 @@
         <h3 id="sidemenu-collapsible">Inklapbaar zijmenu</h3>
         <h4>Visueel voorbeeld</h4>
         <div class="resize">
-          <iframe src="{base}/examples/sidemenu-in-page-collapsible" title="Voorbeeld" height="320px"
+          <iframe
+            src="{base}/examples/sidemenu-in-page-collapsible"
+            title="Voorbeeld"
+            height="320px"
           ></iframe>
         </div>
 

--- a/docs/src/routes/components/sidemenu/in-page/+page.svelte
+++ b/docs/src/routes/components/sidemenu/in-page/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Zijmenu binnen de pagina</h1>
@@ -95,7 +95,7 @@
       <li><a href="/">Voorbeeld link 4</a></li>
     </ul>
   </nav>
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Lorem ipsum</h1>
       <p>Dolor set amet conseqtetur adepicing elit</p>

--- a/docs/src/routes/components/sidemenu/next-to-page-collapsible/+page.svelte
+++ b/docs/src/routes/components/sidemenu/next-to-page-collapsible/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>In- en uitklapbaar zijmenu naast de pagina</h1>

--- a/docs/src/routes/components/sidemenu/next-to-page/+page.svelte
+++ b/docs/src/routes/components/sidemenu/next-to-page/+page.svelte
@@ -21,7 +21,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Zijmenu naast de pagina</h1>
@@ -94,7 +94,7 @@
       </div>
     </header>
     <main>
-      <article class="visually-grouped">
+      <article>
         <div><section>Main</section></div>
       </article>
     </main>

--- a/docs/src/routes/components/skip-to-content/+page.svelte
+++ b/docs/src/routes/components/skip-to-content/+page.svelte
@@ -20,14 +20,17 @@
       <li><a href="#examples">Voorbeelden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>"Ga direct naar inhoud"-knop</h1>
 
-        <p>Voeg gebruiksvriendelijkheid toe voor gebruikers die gebruik maken van hulptechnologiën of enkel met
-          toetsenbord navigeren. Deze knop geeft gebruikers de mogelijkheid om direct naar de inhoud van de pagina te springen. Hiermee
-          wordt voorkomen dat de gebruiker langs onnodig veel elementen moet navigeren.</p>
+        <p>
+          Voeg gebruiksvriendelijkheid toe voor gebruikers die gebruik maken van hulptechnologiën of
+          enkel met toetsenbord navigeren. Deze knop geeft gebruikers de mogelijkheid om direct naar
+          de inhoud van de pagina te springen. Hiermee wordt voorkomen dat de gebruiker langs
+          onnodig veel elementen moet navigeren.
+        </p>
 
         <h2>Benodigde stappen</h2>
 
@@ -41,15 +44,24 @@
 
         <ul>
           <li>Voeg de knop als eerste element binnen de header toe.</li>
-          <li>Verwijs met een <code>&lt;a></code> naar het blok waar de content begint. Dit zal meestal de
-            <code>&lt;main></code> zijn.</li>
-          <li><strong>Let op: de knop is alleen zichtbaar wanneer deze focus krijgt. Gebruik <code>tab</code> om de
-              knop te zien.</strong></li>
-          <li>Voeg <code>tabindex="-1"</code> toe aan de main. De <code>main</code> is een element dat standaard geen
-            focus kan accepteren aangezien het geen control of interactieve content is. Het toevoegen van de tabindex
-            stelt het in staat om toch focus te accepteren.</li>
+          <li>
+            Verwijs met een <code>&lt;a></code> naar het blok waar de content begint. Dit zal
+            meestal de
+            <code>&lt;main></code> zijn.
+          </li>
+          <li>
+            <strong
+              >Let op: de knop is alleen zichtbaar wanneer deze focus krijgt. Gebruik <code
+                >tab</code
+              > om de knop te zien.</strong
+            >
+          </li>
+          <li>
+            Voeg <code>tabindex="-1"</code> toe aan de main. De <code>main</code> is een element dat
+            standaard geen focus kan accepteren aangezien het geen control of interactieve content is.
+            Het toevoegen van de tabindex stelt het in staat om toch focus te accepteren.
+          </li>
         </ul>
-
       </section>
 
       <section id="requirements">
@@ -67,11 +79,14 @@
 
         <h4>Visueel voorbeeld</h4>
         <div class="explanation" role="group" aria-label="Toelichting">
-            <span>Toelichting:</span>
-            <p>De <strong>"Ga direct naar inhoud"-knop</strong> is standaard verborgen voor visuele gebruikers,
-            maar wordt zichtbaar wanneer deze focus krijgt via toetsenbordnavigatie.
-            Dit zorgt ervoor dat de knop niet de visuele opmaak verstoort, maar wel beschikbaar blijft voor gebruikers die er baat bij hebben.
-            Gebruik de <strong>Tab-toets</strong> om de knop te activeren en zichtbaar te maken in het onderstaande voorbeeld.</p>
+          <span>Toelichting:</span>
+          <p>
+            De <strong>"Ga direct naar inhoud"-knop</strong> is standaard verborgen voor visuele
+            gebruikers, maar wordt zichtbaar wanneer deze focus krijgt via toetsenbordnavigatie. Dit
+            zorgt ervoor dat de knop niet de visuele opmaak verstoort, maar wel beschikbaar blijft
+            voor gebruikers die er baat bij hebben. Gebruik de <strong>Tab-toets</strong> om de knop
+            te activeren en zichtbaar te maken in het onderstaande voorbeeld.
+          </p>
         </div>
         <div class="resize">
           <iframe src="{base}/examples/skip-to-content" title="Voorbeeld" height="240px"></iframe>
@@ -108,7 +123,6 @@
               </pre>
         </div>
       </section>
-
     </div>
   </article>
 </main>

--- a/docs/src/routes/components/table-action-buttons/+page.svelte
+++ b/docs/src/routes/components/table-action-buttons/+page.svelte
@@ -22,7 +22,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabel met actieknoppen</h1>

--- a/docs/src/routes/components/table-base/+page.svelte
+++ b/docs/src/routes/components/table-base/+page.svelte
@@ -27,13 +27,13 @@
       <li><a href="#requirements">Benodigde bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabel</h1>
       </section>
 
-      <section id="examples" class="visually-grouped">
+      <section id="examples">
         <h2>Aandachtspunten</h2>
         <p>
           Om tabellen correct weer te geven op smallere schermresoluties, denk hierbij aan mobiele

--- a/docs/src/routes/components/table-caption/+page.svelte
+++ b/docs/src/routes/components/table-caption/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabel bijschrift <code>caption</code></h1>

--- a/docs/src/routes/components/table-checkbox/+page.svelte
+++ b/docs/src/routes/components/table-checkbox/+page.svelte
@@ -29,7 +29,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabelrij met checkbox</h1>

--- a/docs/src/routes/components/table-condensed/+page.svelte
+++ b/docs/src/routes/components/table-condensed/+page.svelte
@@ -22,7 +22,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Gecomprimeerde weergave</h1>

--- a/docs/src/routes/components/table-expando-row/+page.svelte
+++ b/docs/src/routes/components/table-expando-row/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#variables">Beschikbare variabelen</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <p class="warning">
         Let op: Deze tabelstructuur kan als complex ervaren worden door gebruikers. Zeker in

--- a/docs/src/routes/components/table-multiple-columns/+page.svelte
+++ b/docs/src/routes/components/table-multiple-columns/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabeldata over meerdere kolommen</h1>

--- a/docs/src/routes/components/table-multiple-rows/+page.svelte
+++ b/docs/src/routes/components/table-multiple-rows/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabeldata over meerdere rijen</h1>

--- a/docs/src/routes/components/table-notifications/+page.svelte
+++ b/docs/src/routes/components/table-notifications/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Meldingen op tabel-elementen</h1>

--- a/docs/src/routes/components/table-numerical-data/+page.svelte
+++ b/docs/src/routes/components/table-numerical-data/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabel met numerieke data</h1>

--- a/docs/src/routes/components/table-scope/+page.svelte
+++ b/docs/src/routes/components/table-scope/+page.svelte
@@ -22,7 +22,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabelrichting</h1>

--- a/docs/src/routes/components/table-sticky-header/+page.svelte
+++ b/docs/src/routes/components/table-sticky-header/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>"sticky header"</h1>

--- a/docs/src/routes/components/table-summary/+page.svelte
+++ b/docs/src/routes/components/table-summary/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Samenvattingstabel</h1>

--- a/docs/src/routes/components/table/+page.svelte
+++ b/docs/src/routes/components/table/+page.svelte
@@ -11,13 +11,13 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabel</h1>
       </section>
 
-      <section id="available-types" class="visually-grouped">
+      <section id="available-types">
         <h2>Beschikbare weergaven</h2>
         <div class="column-2">
           <nav aria-labelledby="types-heading">

--- a/docs/src/routes/components/tabs-test/+page.svelte
+++ b/docs/src/routes/components/tabs-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabbladen testpagina</h1>

--- a/docs/src/routes/components/tabs/+page.svelte
+++ b/docs/src/routes/components/tabs/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tabbladen</h1>

--- a/docs/src/routes/components/tag/+page.svelte
+++ b/docs/src/routes/components/tag/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tag</h1>

--- a/docs/src/routes/components/tags/+page.svelte
+++ b/docs/src/routes/components/tags/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tags</h1>

--- a/docs/src/routes/components/tile-cover-image/+page.svelte
+++ b/docs/src/routes/components/tile-cover-image/+page.svelte
@@ -20,7 +20,7 @@
       <li><a href="#requirements">Bijbehorende bestanden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tegelweergave met cover-afbeelding</h1>

--- a/docs/src/routes/components/tile-groups-test/+page.svelte
+++ b/docs/src/routes/components/tile-groups-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tegelweergave testpagina</h1>

--- a/docs/src/routes/components/tile-groups/+page.svelte
+++ b/docs/src/routes/components/tile-groups/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Gegroepeerde content binnen tegels</h1>

--- a/docs/src/routes/components/tiles-test/+page.svelte
+++ b/docs/src/routes/components/tiles-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tegelweergave testpagina</h1>

--- a/docs/src/routes/components/tiles/+page.svelte
+++ b/docs/src/routes/components/tiles/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Tegelweergave</h1>

--- a/docs/src/routes/documentation/+page.svelte
+++ b/docs/src/routes/documentation/+page.svelte
@@ -22,7 +22,7 @@
     </div>
   </section>
 
-  <section class="visually-grouped">
+  <section>
     <div>
       <h2>Snel aan de slag</h2>
       <p>
@@ -97,7 +97,7 @@
     </div>
   </section>
 
-  <section class="visually-grouped">
+  <section>
     <div>
       <h2 id="instructions-heading">Meer instructies</h2>
       <nav aria-labelledby="instructions-heading">
@@ -114,7 +114,7 @@
     </div>
   </section>
 
-  <section class="visually-grouped">
+  <section>
     <div>
       <h2>Manon installeren voor development</h2>
       <p>

--- a/docs/src/routes/documentation/use-css-variable/+page.svelte
+++ b/docs/src/routes/documentation/use-css-variable/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>CSS-variabelen gebruiken</h1>

--- a/docs/src/routes/examples/sidemenu-in-page-collapsible/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-in-page-collapsible/+page.svelte
@@ -26,7 +26,7 @@
       <li><a href={page.url.pathname}>Voorbeeld-link 4</a></li>
     </ul>
   </nav>
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Lorem ipsum</h1>
       <p>Dolor sit amet conseqtetur adepicing elit</p>

--- a/docs/src/routes/examples/sidemenu-in-page-expandable/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-in-page-expandable/+page.svelte
@@ -26,7 +26,7 @@
       <li><a href={page.url.pathname}>Voorbeeld-link 4</a></li>
     </ul>
   </nav>
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Lorem ipsum</h1>
       <p>Dolor sit amet conseqtetur adepicing elit</p>

--- a/docs/src/routes/examples/sidemenu-in-page/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-in-page/+page.svelte
@@ -23,7 +23,7 @@
       <li><a href={page.url.pathname}>Voorbeeld-link 4</a></li>
     </ul>
   </nav>
-  <article class="visually-grouped">
+  <article>
     <div>
       <h1>Lorem ipsum</h1>
       <p>Dolor sit amet conseqtetur adepicing elit</p>

--- a/docs/src/routes/examples/sidemenu-next-to-page-collapsible/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-next-to-page-collapsible/+page.svelte
@@ -29,7 +29,7 @@
     </div>
   </header>
   <main>
-    <article class="visually-grouped">
+    <article>
       <div><section>Main</section></div>
     </article>
   </main>

--- a/docs/src/routes/examples/sidemenu-next-to-page-expandable/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-next-to-page-expandable/+page.svelte
@@ -29,7 +29,7 @@
     </div>
   </header>
   <main>
-    <article class="visually-grouped">
+    <article>
       <div><section>Main</section></div>
     </article>
   </main>

--- a/docs/src/routes/examples/sidemenu-next-to-page/+page.svelte
+++ b/docs/src/routes/examples/sidemenu-next-to-page/+page.svelte
@@ -26,7 +26,7 @@
     </div>
   </header>
   <main>
-    <article class="visually-grouped">
+    <article>
       <div><section>Main</section></div>
     </article>
   </main>

--- a/docs/src/routes/utility/+page.svelte
+++ b/docs/src/routes/utility/+page.svelte
@@ -18,7 +18,7 @@
     </div>
   </section>
 
-  <section id="utility" class="visually-grouped column-3">
+  <section id="utility" class="column-3">
     <nav aria-labelledby="utility-classes-heading">
       <h2>Zichtbaarheid</h2>
       <ul>

--- a/docs/src/routes/utility/centered-test/+page.svelte
+++ b/docs/src/routes/utility/centered-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout gecentreerd testpagina</h1>

--- a/docs/src/routes/utility/centered/+page.svelte
+++ b/docs/src/routes/utility/centered/+page.svelte
@@ -23,7 +23,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout gecentreerd</h1>

--- a/docs/src/routes/utility/column-2-test/+page.svelte
+++ b/docs/src/routes/utility/column-2-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout twee kolommen testpagina</h1>
@@ -110,7 +110,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <div class="column-2">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -119,7 +119,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -134,12 +134,12 @@
           language="html"
           code={`
 <div class="column-2">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -241,7 +241,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <section class="column-2">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -250,7 +250,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -265,12 +265,12 @@
           language="html"
           code={`
 <section class="column-2">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -372,7 +372,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <article class="column-2">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -381,7 +381,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -396,12 +396,12 @@
           language="html"
           code={`
 <article class="column-2">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/column-2/+page.svelte
+++ b/docs/src/routes/utility/column-2/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout twee kolommen</h1>

--- a/docs/src/routes/utility/column-3-test/+page.svelte
+++ b/docs/src/routes/utility/column-3-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout drie kolommen testpagina</h1>
@@ -138,7 +138,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <div class="column-3">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -147,7 +147,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -156,7 +156,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -171,17 +171,17 @@
           language="html"
           code={`
 <div class="column-3">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -311,7 +311,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <section class="column-3">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -320,7 +320,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -329,7 +329,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -344,17 +344,17 @@
           language="html"
           code={`
 <section class="column-3">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -484,7 +484,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <article class="column-3">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -493,7 +493,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -502,7 +502,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -517,17 +517,17 @@
           language="html"
           code={`
 <article class="column-3">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/column-3/+page.svelte
+++ b/docs/src/routes/utility/column-3/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout drie kolommen</h1>

--- a/docs/src/routes/utility/column-4-test/+page.svelte
+++ b/docs/src/routes/utility/column-4-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout vier kolommen testpagina</h1>
@@ -166,7 +166,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <div class="column-4">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -175,7 +175,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -184,7 +184,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -193,7 +193,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -208,22 +208,22 @@
           language="html"
           code={`
 <div class="column-4">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -381,7 +381,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <section class="column-4">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -390,7 +390,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -399,7 +399,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -408,7 +408,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -423,22 +423,22 @@
           language="html"
           code={`
 <section class="column-4">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -596,7 +596,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <article class="column-4">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -605,7 +605,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -614,7 +614,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -623,7 +623,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -638,22 +638,22 @@
           language="html"
           code={`
 <article class="column-4">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/column-4/+page.svelte
+++ b/docs/src/routes/utility/column-4/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout vier kolommen</h1>

--- a/docs/src/routes/utility/fifty-fifty-test/+page.svelte
+++ b/docs/src/routes/utility/fifty-fifty-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout fifty-fifty testpagina</h1>
@@ -159,7 +159,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <div class="fifty-fifty">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -168,7 +168,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -183,12 +183,12 @@
           language="html"
           code={`
 <div class="fifty-fifty">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -290,7 +290,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <section class="fifty-fifty">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -299,7 +299,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -314,12 +314,12 @@
           language="html"
           code={`
 <section class="fifty-fifty">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -421,7 +421,7 @@
         </p>
         <h4>Visueel voorbeeld:</h4>
         <article class="fifty-fifty">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -430,7 +430,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -445,12 +445,12 @@
           language="html"
           code={`
 <article class="fifty-fifty">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/fifty-fifty/+page.svelte
+++ b/docs/src/routes/utility/fifty-fifty/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout fifty-fifty</h1>

--- a/docs/src/routes/utility/focus-only-test/+page.svelte
+++ b/docs/src/routes/utility/focus-only-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Focus only testpagina</h1>

--- a/docs/src/routes/utility/focus-only/+page.svelte
+++ b/docs/src/routes/utility/focus-only/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>"Focus only"</h1>

--- a/docs/src/routes/utility/hidden/+page.svelte
+++ b/docs/src/routes/utility/hidden/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Verbergen - <dfn>hidden</dfn></h1>

--- a/docs/src/routes/utility/horizontal-center-test/+page.svelte
+++ b/docs/src/routes/utility/horizontal-center-test/+page.svelte
@@ -18,7 +18,7 @@
       <li><a href="#tests">Tests en voorbeelden</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal gecentreerd testpagina</h1>

--- a/docs/src/routes/utility/horizontal-center/+page.svelte
+++ b/docs/src/routes/utility/horizontal-center/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal gecentreerd</h1>

--- a/docs/src/routes/utility/horizontal-scroll-test/+page.svelte
+++ b/docs/src/routes/utility/horizontal-scroll-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontale scroll testpagina</h1>

--- a/docs/src/routes/utility/horizontal-scroll/+page.svelte
+++ b/docs/src/routes/utility/horizontal-scroll/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontale scroll</h1>

--- a/docs/src/routes/utility/horizontal-test/+page.svelte
+++ b/docs/src/routes/utility/horizontal-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal uitgelijnd testpagina</h1>

--- a/docs/src/routes/utility/horizontal/+page.svelte
+++ b/docs/src/routes/utility/horizontal/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontaal uitgelijnd</h1>

--- a/docs/src/routes/utility/nowrap-test/+page.svelte
+++ b/docs/src/routes/utility/nowrap-test/+page.svelte
@@ -12,7 +12,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Horizontale scroll testpagina</h1>

--- a/docs/src/routes/utility/nowrap/+page.svelte
+++ b/docs/src/routes/utility/nowrap/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>nowrap</h1>

--- a/docs/src/routes/utility/one-third-two-thirds-test/+page.svelte
+++ b/docs/src/routes/utility/one-third-two-thirds-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout eenderde tweederde testpagina</h1>
@@ -266,7 +266,7 @@
         <p>Gegroepeerde content binnen een <code>div</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <div class="one-third-two-thirds">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -275,7 +275,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -389,7 +389,7 @@
         <p>Elementen uitlijnen binnen een <code>section</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <section class="one-third-two-thirds">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -398,7 +398,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -413,12 +413,12 @@
           language="html"
           code={`
 <section class="one-third-two-thirds">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -512,7 +512,7 @@
         <p>Elementen uitlijnen binnen een <code>article</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <article class="one-third-two-thirds">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -521,7 +521,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -536,12 +536,12 @@
           language="html"
           code={`
 <article class="one-third-two-thirds">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/one-third-two-thirds/+page.svelte
+++ b/docs/src/routes/utility/one-third-two-thirds/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout eenderde tweederde</h1>

--- a/docs/src/routes/utility/two-thirds-one-third-test/+page.svelte
+++ b/docs/src/routes/utility/two-thirds-one-third-test/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <main id="main-content" tabindex="-1">
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout tweederde eenderde testpagina</h1>
@@ -297,7 +297,7 @@
         <p>Gegroepeerde content binnen een <code>div</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <div class="two-thirds-one-third">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -306,7 +306,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -420,7 +420,7 @@
         <p>Elementen uitlijnen binnen een <code>section</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <section class="two-thirds-one-third">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -429,7 +429,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -444,12 +444,12 @@
           language="html"
           code={`
 <section class="two-thirds-one-third">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
@@ -543,7 +543,7 @@
         <p>Elementen uitlijnen binnen een <code>article</code> met <code>article</code>'s.</p>
         <h4>Visueel voorbeeld:</h4>
         <article class="two-thirds-one-third">
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -552,7 +552,7 @@
             </p>
           </article>
 
-          <article class="visually-grouped">
+          <article>
             <h2>Lorem ipsum dolor set</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim
@@ -567,12 +567,12 @@
           language="html"
           code={`
 <article class="two-thirds-one-third">
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>
 
-  <article class="visually-grouped">
+  <article>
     <h2>Lorem ipsum dolor set</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue ac enim luctus, vitae iaculis magna vestibulum. Aenean est mauris, condimentum et molestie sed, tempus in massa.</p>
   </article>

--- a/docs/src/routes/utility/two-thirds-one-third/+page.svelte
+++ b/docs/src/routes/utility/two-thirds-one-third/+page.svelte
@@ -21,7 +21,7 @@
       <li><a href="#related">Gerelateerde pagina's</a></li>
     </ul>
   </SideMenu>
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Layout tweederde eenderde</h1>

--- a/docs/src/routes/utility/visually-hidden/+page.svelte
+++ b/docs/src/routes/utility/visually-hidden/+page.svelte
@@ -22,7 +22,7 @@
     </ul>
   </SideMenu>
 
-  <article class="visually-grouped">
+  <article>
     <div>
       <section id="introduction">
         <h1>Visueel verbergen - <dfn>visually hidden</dfn></h1>


### PR DESCRIPTION
Removing class visually-grouped as it is no longer in use and specific to iCore Open theme and as such not desirable in the docs.
 