### PR TITLE
docs: remove incorrect aria-labels from examples

### DIFF
--- a/docs/src/routes/components/button-dropdown/+page.svelte
+++ b/docs/src/routes/components/button-dropdown/+page.svelte
@@ -46,7 +46,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible dropdown"
         >
           <div class="collapsing-element">
@@ -66,7 +65,6 @@
 data-open-label="Dropdown menu"
 data-close-label="Sluit dropdown menu"
 data-media="(min-width: 100%)"
-aria-label="Acties"
 class="collapsible">
 
 <div class="collapsing-element">
@@ -88,7 +86,6 @@ class="collapsible">
             data-open-label="O"
             data-close-label="X"
             data-media="(min-width: 100%)"
-            aria-label="Acties"
             class="collapsible dropdown"
           >
             <div class="collapsing-element">
@@ -104,7 +101,6 @@ class="collapsible">
             data-open-label="Dropdown menu"
             data-close-label="Sluit dropdown menu"
             data-media="(min-width: 100%)"
-            aria-label="Acties"
             class="collapsible dropdown"
           >
             <div class="collapsing-element">
@@ -125,7 +121,6 @@ class="collapsible">
 data-open-label="Dropdown menu"
 data-close-label="Sluit dropdown menu"
 data-media="(min-width: 100%)"
-aria-label="Acties"
 class="collapsible">
 
 <div class="collapsing-element">

--- a/docs/src/routes/components/collapsible/+page.svelte
+++ b/docs/src/routes/components/collapsible/+page.svelte
@@ -70,7 +70,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -90,7 +89,6 @@
   data-open-label="Dropdown menu"
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -139,7 +137,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -161,7 +158,6 @@
   data-open-label="Dropdown menu"
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -182,7 +178,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -204,7 +199,6 @@
   data-open-label="Dropdown menu"
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -228,7 +222,6 @@
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
           data-button-classes="ghost"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -249,7 +242,6 @@
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
   data-button-classes="ghost"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -271,7 +263,6 @@
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
           data-button-classes="icon icon-cat"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -292,7 +283,6 @@
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
   data-button-classes="icon icon-cat"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -312,7 +302,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -338,7 +327,6 @@
   data-open-label="Dropdown menu"
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">
@@ -365,7 +353,6 @@
           data-open-label="Dropdown menu"
           data-close-label="Sluit dropdown menu"
           data-media="(min-width: 100%)"
-          aria-label="Acties"
           class="collapsible"
         >
           <div class="collapsing-element">
@@ -401,7 +388,6 @@
   data-open-label="Dropdown menu"
   data-close-label="Sluit dropdown menu"
   data-media="(min-width: 100%)"
-  aria-label="Acties"
   class="collapsible">
 
   <div class="collapsing-element">


### PR DESCRIPTION
Remove the `aria-label` from [elements that don't support it](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label#associated_roles) in the example snippets for the `collapsible` and `button-dropdown` components. The documentation did provide any instructions about adding `aria-label`, so the example snippets were the only things that needed to be changed.

Closes #434.