### PR TITLE
build: correctly rebase iframe src URLs, build docs with BASE_PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build
+        env:
+          # Not strictly necessary here, but good to check for BASE_PATH-related
+          # build issues early, since we need BASE_PATH for github pages.
+          BASE_PATH: "/${{ github.event.repository.name }}"
         run: pnpm run build
 
   sonarcloud:

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,7 @@
     "svelte-check": "^4.3.0",
     "svelte-preprocess-import-assets": "^1.1.0",
     "typescript": "^5.8.3",
+    "unist-util-visit": "^5.0.0",
     "vite": "^7.0.6"
   }
 }

--- a/docs/src/markdown/remark/iframe.js
+++ b/docs/src/markdown/remark/iframe.js
@@ -1,0 +1,21 @@
+/**
+ * @import type { Root } from 'mdast'
+ */
+
+import { visit } from "unist-util-visit";
+
+const iframeTagPattern = /<\s*?iframe[\s\S]*?>|<\/\s*?iframe\s*?>/g;
+
+/**
+ * Remark plugin to rewrite <iframe> to <Component.iframe> (for mdsvex).
+ * @returns {(ast: Root) => undefined}
+ */
+export function remarkIframe() {
+  return function (ast) {
+    visit(ast, "html", (node) => {
+      node.value = node.value.replaceAll(iframeTagPattern, (match) =>
+        match.replace("iframe", "Components.iframe"),
+      );
+    });
+  };
+}

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -4,6 +4,7 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { importAssets } from "svelte-preprocess-import-assets";
 import { mdsvex } from "mdsvex";
 import { redirects } from "./src/redirects.js";
+import { remarkIframe } from "./src/markdown/remark/iframe.js";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -26,6 +27,7 @@ const config = {
     vitePreprocess(),
     mdsvex({
       extensions: [".md"],
+      remarkPlugins: [remarkIframe],
       layout: {
         _: fileURLToPath(import.meta.resolve("./src/markdown/layouts/default.svelte")),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       vite:
         specifier: ^7.0.6
         version: 7.0.6(sass@1.89.2)(terser@5.29.2)
@@ -564,6 +567,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -1189,14 +1195,23 @@ packages:
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
   unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
 
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
   unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1587,6 +1602,8 @@ snapshots:
       '@types/unist': 2.0.11
 
   '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   acorn@8.15.0: {}
 
@@ -2223,6 +2240,10 @@ snapshots:
 
   unist-util-is@4.1.0: {}
 
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
@@ -2232,11 +2253,22 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
 
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
   unist-util-visit@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Fix the issue that was causing the [github-pages workflow failures on `main`](https://github.com/minvws/nl-rdo-manon/actions/runs/16726931460) and add a `BASE_PATH` to the CI docs build to make sure it will block future PRs that would break the github pages workflow.