### PR TITLE
ci: run CI workflow on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, "release/**"]
   pull_request:
-    branches: [main, "release/**"]
 
 jobs:
   audit:


### PR DESCRIPTION
Change the "CI" workflow to trigger on any PR instead of just PRs to `main` or `release/**`.
