### PR TITLE
ci: publish github-pages from version tags instead of main

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,8 +2,7 @@ name: Deploy docs
 
 on:
   push:
-    branches: ["main"]
-  workflow_dispatch:
+    tags: ["v*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Change the github-pages workflow's `push` trigger from the "main" branch to "v*" tags, and remove the `workflow_dispatch` trigger to avoid accidentally publishing "main" anyway.
