### PR TITLE
fix: block notification alignment

### DIFF
--- a/manon/notification-block-element.scss
+++ b/manon/notification-block-element.scss
@@ -10,7 +10,6 @@
   align-items: var(--notification-block-element-align-items);
   gap: var(--notification-block-element-gap);
   width: var(--notification-block-element-width);
-  margin: 0 auto;
   box-sizing: border-box;
   padding-top: var(--notification-block-element-padding-top);
   padding-right: var(--notification-block-element-padding-right);


### PR DESCRIPTION
Removes margin auto as it unnecessarily centers the notification