### PR TITLE
Refactor fonts import

### DIFF
--- a/themes/kat/fonts/open-sans/_index.scss
+++ b/themes/kat/fonts/open-sans/_index.scss
@@ -1,33 +1,18 @@
 @use "../../config";
 
-@font-face {
-  font-family: "Open Sans";
-  font-weight: normal;
-  font-style: normal;
-  src: url("#{config.$font-path}/open-sans/OpenSans-Regular.ttf")
-    format("truetype");
-}
+$font-path: "#{config.$font-path}/open-sans";
 
-@font-face {
-  font-family: "Open Sans";
-  font-weight: normal;
-  font-style: italic;
-  src: url("#{config.$font-path}/open-sans/OpenSans-Italic.ttf")
-    format("truetype");
-}
+$fonts: (
+  (normal, italic, OpenSans-Italic),
+  (bold, normal, OpenSans-Bold),
+  (bold, italic, OpenSans-BoldItalic)
+);
 
-@font-face {
-  font-family: "Open Sans";
-  font-weight: bold;
-  font-style: normal;
-  src: url("#{config.$font-path}/open-sans/OpenSans-Bold.ttf")
-    format("truetype");
-}
-
-@font-face {
-  font-family: "Open Sans";
-  font-weight: bold;
-  font-style: italic;
-  src: url("#{config.$font-path}/open-sans/OpenSans-BoldItalic.ttf")
-    format("truetype");
+@each $weight, $style, $file in $fonts {
+  @font-face {
+    font-family: "Open Sans";
+    font-weight: $weight;
+    font-style: $style;
+    src: url("#{$font-path}/#{$file}.ttf") format("truetype");
+  }
 }


### PR DESCRIPTION
When importing fonts for the same type, here Open Sans, we repeat certain things that can be this way automated. This will also reduce typo's for the same fonts. 