### PR TITLE
ci: use generic sonarqube action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,6 @@ jobs:
           fetch-depth: 0
 
       - name: 'Run SonarQube cloud scanner'
-        uses: minvws/nl-irealisatie-generic-pipelines/.github/actions/sonarcloud@main
+        uses: minvws/action-sonarqube@v1
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This PR updates the CI to use the generic sonarqube action.