### PR TITLE
Fixes font-size inheritance issue for a tags #359

### DIFF
--- a/manon/link.scss
+++ b/manon/link.scss
@@ -14,3 +14,7 @@ a {
   @include link.link-elements-styling("link-");
   @include outline.outline("link-");
 }
+
+* a {
+  font-size: inherit;
+}


### PR DESCRIPTION
Fixes:
https://github.com/minvws/nl-rdo-manon/issues/359

Issue is with nested a tags not inheriting font-size.
This fix ensures nested a tags inherit font-size.
Has been tested with p, h1 - h6, main, section and article tags as parent of an a tag