### PR TITLE
fix: #419 update tile-image-cover component, element order for screen readers

### DIFF
--- a/manon/tile-image-cover.scss
+++ b/manon/tile-image-cover.scss
@@ -29,12 +29,6 @@
   }
 }
 
-.tile.image-cover {
-  img {
-    @extend %tile-image-cover;
-  }
-}
-
 .tiles.images-cover {
   > div,
   li {


### PR DESCRIPTION
Attempts to solve #419. 

I'm not sure if this is according to the requirements however (which is way I opened in draft). The order of the elements has been fixed, but now the cover image stretches the full width of the container instead of keeping its natural size without any additional styling.

Main:
<img width="1133" height="318" alt="Screenshot 2025-08-29 at 09 01 17" src="https://github.com/user-attachments/assets/321d5fa5-fae6-4198-9e51-21a9cccbb08e" />

This branch:
<img width="1440" height="308" alt="Screenshot 2025-08-29 at 09 04 15" src="https://github.com/user-attachments/assets/f4f3a4e2-fa16-4154-bc80-1bd9f0f59966" />

When I look at https://minvws.github.io/nl-rdo-manon/components/tile-cover-image the image stretches the full width of the container too, maybe it is correct after all?

