### PR TITLE
fix: styling for elements with aria-current attribute (pagination)

### DIFF
--- a/manon/pagination.scss
+++ b/manon/pagination.scss
@@ -35,7 +35,8 @@
     border-color: var(--pagination-link-hover-border-color);
   }
 
-  &[aria-current] {
+  &[aria-current="page"],
+  &[aria-current="true"] {
     @extend %pagination-active-item-styling;
   }
 


### PR DESCRIPTION
This PR solves https://github.com/minvws/nl-rdo-manon/issues/653. Added styling rules for both `[aria-current="page"]` like suggested in the comment, and for `[aria-current="true"]` since that is what the documentation suggests using:
https://minvws.github.io/nl-rdo-manon/components/pagination

Alternatively I can also update the docs to reflect =page instead of =true