### PR TITLE
fix: remove required form wrapper from radio inputs (#358)

### DIFF
--- a/manon/radio.scss
+++ b/manon/radio.scss
@@ -3,51 +3,49 @@
 /*---------------------------------------------------------------*/
 @use "radio-variables";
 
-form {
-  .radio {
+.radio {
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  gap: var(--radio-gap);
+  align-items: var(--radio-align-items);
+
+  input[type="radio"] {
     padding: 0;
-    display: flex;
-    flex-direction: row;
-    gap: var(--radio-gap);
-    align-items: var(--radio-align-items);
+    cursor: pointer;
+    width: var(--radio-input-width);
+    min-width: var(--radio-input-width);
+    height: var(--radio-input-height);
+    accent-color: var(--radio-input-accent-color);
 
-    input[type="radio"] {
-      padding: 0;
+    & + label {
+      width: var(--radio-label-width);
       cursor: pointer;
-      width: var(--radio-input-width);
-      min-width: var(--radio-input-width);
-      height: var(--radio-input-height);
-      accent-color: var(--radio-input-accent-color);
-
-      & + label {
-        width: var(--radio-label-width);
-        cursor: pointer;
-      }
-
-      &:disabled {
-        cursor: not-allowed;
-
-        & + label {
-          cursor: not-allowed;
-        }
-      }
     }
 
-    &.required {
-      flex-direction: column;
-      gap: var(--radio-required-gap);
-      align-items: flex-start;
-      justify-content: var(
-        --radio-align-items
-      ); /* Using alignment value because the flex direction is column */
+    &:disabled {
+      cursor: not-allowed;
 
-      > div {
-        padding: 0;
-        display: flex;
-        flex-direction: row;
-        gap: var(--radio-gap);
-        align-items: var(--radio-align-items);
+      & + label {
+        cursor: not-allowed;
       }
+    }
+  }
+
+  &.required {
+    flex-direction: column;
+    gap: var(--radio-required-gap);
+    align-items: flex-start;
+    justify-content: var(
+      --radio-align-items
+    ); /* Using alignment value because the flex direction is column */
+
+    > div {
+      padding: 0;
+      display: flex;
+      flex-direction: row;
+      gap: var(--radio-gap);
+      align-items: var(--radio-align-items);
     }
   }
 }


### PR DESCRIPTION
**Related issue:** #358

## Changes
- Removed dependency on parent `<form>` for `.radio` styling  
- Radios can now be used with or without a wrapper  

## Example

### With `<form>` wrapper (still supported)
```html
<form action="" method="post">
  <div class="radio">
    <input type="radio" id="radio-example-1" name="example">
    <label for="radio-example-1">Option with form wrapper</label>
  </div>
</form>
```

### Without <form> wrapper (now supported)
```html
<div class="radio">
  <input type="radio" id="radio-example-1" name="example">
  <label for="radio-example-1">Option with form wrapper</label>
</div>
```