### PR TITLE
chore: enable typescript checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+  check-types:
+    name: Check types
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Check types
+        run: pnpm run --dir manon check
+
   check-formatting:
     name: Check formatting
     runs-on: ubuntu-24.04

--- a/manon/package.json
+++ b/manon/package.json
@@ -15,6 +15,8 @@
     "format:check": "prettier --check .",
     "lint:css": "stylelint \"**/*.scss\"",
     "lint:css:fix": "npm run lint:css -- --fix",
+    "check": "tsc",
+    "check:watch": "tsc --watch",
     "npm-version": "npm version",
     "test": "vitest run"
   },

--- a/manon/tsconfig.json
+++ b/manon/tsconfig.json
@@ -1,7 +1,14 @@
 {
-  "include": ["*.js", "**/*.js"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "moduleResolution": "bundler",
     "noEmit": true,
-    "allowJs": true
-  }
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true
+  },
+  "include": ["./*.js", "./bin/", "./js/"],
+  "exclude": ["../node_modules/**"]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     }
   },
   "devDependencies": {
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
 
   docs:
     dependencies:


### PR DESCRIPTION
Add typescript type checking in `*.js` files in the `manon` package. Types can be inferred or, when necessary, annotated via JSDoc comments (see e.g. #1038). This way we have type safety without needing a build step for JS.