### PR TITLE
fix: issue with `<a>` tag in navigation component documentation

### DIFF
--- a/docs/src/routes/library/components/navigation/+page.md
+++ b/docs/src/routes/library/components/navigation/+page.md
@@ -45,7 +45,7 @@ SCSS importeren:
 
 <nav>
     <ul class="horizontal">
-        <li><a href="#">Voorbeeld-link 1</li>
+        <li><a href="#">Voorbeeld-link 1</a></li>
         <li><a href="#">Voorbeeld-link 2</a></li>
         <li><a href="#">Voorbeeld-link 3</a></li>
     </ul>


### PR DESCRIPTION
This PR fixes the closing `<a>` tag issue in the navigation component documentation