### PR TITLE
Fix pagination alignment

### DIFF
--- a/manon/components/pagination.scss
+++ b/manon/components/pagination.scss
@@ -182,11 +182,11 @@ nav.pagination,
 .pagination {
   display: flex;
   width: 100%;
+  align-items: theme.$pagination-align-items;
 
   @include theming.apply-from-theme(
     (
       justify-content: theme.$pagination-justify-content,
-      align-items: theme.$pagination-align-items,
       border-width: theme.$pagination-border-width,
       border-style: theme.$pagination-border-style,
       border-color: theme.$pagination-border-color,

--- a/manon/variables/_pagination.scss
+++ b/manon/variables/_pagination.scss
@@ -68,7 +68,7 @@ $pagination-item-width: null !default;
 
 // Nav
 $pagination-justify-content: null !default;
-$pagination-align-items: null !default;
+$pagination-align-items: center;
 $pagination-border-width: null !default;
 $pagination-border-style: null !default;
 $pagination-border-color: null !default;

--- a/manon/variables/_pagination.scss
+++ b/manon/variables/_pagination.scss
@@ -68,7 +68,7 @@ $pagination-item-width: null !default;
 
 // Nav
 $pagination-justify-content: null !default;
-$pagination-align-items: center;
+$pagination-align-items: center !default;
 $pagination-border-width: null !default;
 $pagination-border-style: null !default;
 $pagination-border-color: null !default;


### PR DESCRIPTION
Fix center alignment of previous and next with pagination.
<img width="962" height="212" alt="image" src="https://github.com/user-attachments/assets/3f4b31bc-f454-436d-8a09-5109f76c2db2" />

Fix:
<img width="1004" height="275" alt="image" src="https://github.com/user-attachments/assets/ba49109f-68f7-490e-8e69-63b1ab51364d" />

