### PR TITLE
fix: typography examples

### DIFF
--- a/docs/src/routes/library/typography/de-emphasized/+page.md
+++ b/docs/src/routes/library/typography/de-emphasized/+page.md
@@ -16,7 +16,6 @@ Voor een subtielere weergave van bepaalde teksten kan de class `de-emphasized` w
 SCSS importeren:
 
 ```scss
-@use "@minvws/manon/body-text-set";
 @use "@minvws/manon/de-emphasized";
 ```
 

--- a/docs/src/routes/library/typography/emphasized/+page.md
+++ b/docs/src/routes/library/typography/emphasized/+page.md
@@ -18,7 +18,6 @@ nadruk op de tekst, waardoor deze opvalt binnen de context van de pagina.
 SCSS importeren:
 
 ```scss
-@use "@minvws/manon/body-text-set";
 @use "@minvws/manon/emphasized";
 ```
 

--- a/docs/src/routes/library/typography/headings/+page.md
+++ b/docs/src/routes/library/typography/headings/+page.md
@@ -21,30 +21,6 @@ Gebruik titels om structuur binnen de pagina aan te geven.
 @use "@minvws/manon/headings";
 ```
 
-<div class="explanation" role="group" aria-label="Toelichting">
-  <span>Aandachtspunten</span>
-  <ul>
-    <li>
-      Gebruik altijd een `h1` per pagina.
-    </li>
-    <li>
-      Kies altijd het juiste titel-element uit `h1` &gt; `h6` op basis van de structuur in de HTML. Niet op basis van de visuele weergave.
-    </li>
-    <li>
-      HTML-elementen h1 > h6 kunnen via de css voorzien worden van stijl. Voor meer informatie zie: [voorbeelden](#examples).
-    </li>
-    <li>
-      Als niet ieder gelijkwaardig titel-element, bijvoorbeeld een h1, dezelfde visuele stijling gebruikt kan de stijl gezet worden door middel van een voorgedefineerde set. Binnen deze set worden de beschikbare "heading-styles" vastgelegd. Denk bijvoorbeeld aan een "heading-large" of een "heading-small". Voor meer informatie hierover zie: [Titel basisset](heading-base-set).
-    </li>
-  </ul>
-</div>
-
-<p class="warning">
-  <strong>Let op:</strong> Eerder was het gebruik van meerdere `h1`'s per pagina toegestaan. Dit is
-  gewijzigd in de HTML-specs van whatwg. Voor meer informatie hierover zie:
-  <a href="https://github.com/whatwg/html/commit/6682bdeee6fb08f5972bea92064fe250f1b4ec9c">Commit van whatwg</a>.
-</p>
-
 <h2 id="examples">Voorbeelden:</h2>
 
 <div class="visual-example">
@@ -63,4 +39,29 @@ Gebruik titels om structuur binnen de pagina aan te geven.
 <h4>Dit is een h4</h4>
 <h5>Dit is een h5</h5>
 <h6>Dit is een h6</h6>
+```
+
+Kies altijd het juiste titel-element uit `h1` > `h6` op basis van de structuur in de HTML. De visuele weergaven van de headers kan waar nodig aangepast worden met een heading-class. 
+
+Voeg heading-base-set toe aan je applicatie om gebruik te maken van deze uitzonderingen.
+
+Beschikbare opties: 
+- heading-xxl
+- heading-xl
+- heading-large
+- heading-normal
+- heading-xs
+
+```scss
+@use "@minvws/manon/headings-base-set";
+```
+
+<div class="visual-example">
+  <h2>Dit is een h2</h2>
+  <h2 class="heading-xs">Dit is ook een h2 maar visueel kleiner weergegeven.</h2>
+</div>
+
+```html
+<h2>Dit is een h2</h2>
+<h2 class="heading-xs">Dit is ook een h2 maar visueel kleiner weergegeven.</h2>
 ```


### PR DESCRIPTION
- Fixes examples within the documentation for: emphasized, de-emphasized and headings.