### PR TITLE
fix: img with icon class behaviour

### DIFF
--- a/manon/components/icon.scss
+++ b/manon/components/icon.scss
@@ -9,7 +9,7 @@
   display: inline-block;
 }
 
-svg, 
+svg,
 img {
   &.icon {
     background-color: transparent;


### PR DESCRIPTION
Solves the issue where img with the class icon are filled in with a solid color. 


Before: 
<img width="196" height="141" alt="Screenshot 2025-10-20 at 14 38 41" src="https://github.com/user-attachments/assets/d184c858-286c-4993-9c2b-69117cf38d34" />

After: 
<img width="201" height="139" alt="Screenshot 2025-10-20 at 14 38 30" src="https://github.com/user-attachments/assets/4dd28ee6-9e07-4fb2-aa25-13bb91c46865" />
