### PR TITLE
fix: sticky sidemenu behaviour

### DIFF
--- a/docs/src/lib/SideMenu.svelte
+++ b/docs/src/lib/SideMenu.svelte
@@ -13,5 +13,7 @@
   aria-label="Document-navigatie"
   {...props}
 >
-  {@render props.children?.()}
+  <div class="sticky-container">
+    {@render props.children?.()}
+  </div>
 </nav>

--- a/manon/components/sidemenu.scss
+++ b/manon/components/sidemenu.scss
@@ -1,7 +1,7 @@
 @use "../mixins/theming";
 @use "../variables" as theme;
 
-$sidemenu-breakpoint: 55rem !default;
+$sidemenu-breakpoint: 24rem !default;
 
 body.sidemenu,
 main.sidemenu {
@@ -87,7 +87,7 @@ main.sidemenu {
       );
 
       /* List */
-      > ul {
+      .sticky-container {
         position: -webkit-sticky;
         position: sticky;
         top: 0;


### PR DESCRIPTION
Fixes issue where nested elements within a sticky sidemenu got stacked on top of each other instead of underneath each other.