### PR TITLE
fix: fixes link text decoration

### DIFF
--- a/manon/components/link.scss
+++ b/manon/components/link.scss
@@ -5,10 +5,7 @@ a {
   display: theme.$link-display;
   align-items: theme.$link-align-items;
   color: theme.$link-text-color;
-
-  // Overriding default text decoration to add consistent underline on icons
-  text-decoration: unset;
-  border-bottom: theme.$link-text-decoration;
+  text-decoration: theme.$link-text-decoration;
 
   // Icon
   span.icon {

--- a/manon/variables/_link.scss
+++ b/manon/variables/_link.scss
@@ -1,5 +1,5 @@
 $link-text-color: null !default;
-$link-text-decoration: 1px solid !default;
+$link-text-decoration: null !default;
 $link-display: inline-flex !default;
 $link-align-items: center !default;
 


### PR DESCRIPTION
Simplifies link text-underline styling as the current "fix" was causing issues.