### PR TITLE
fix: fieldset alignment

### DIFF
--- a/manon/components/form-fieldset.scss
+++ b/manon/components/form-fieldset.scss
@@ -22,6 +22,7 @@ main article form,
 main div form {
   > fieldset {
     padding: theme.$form-fieldset-padding;
+    margin: theme.$form-fieldset-margin;
     border-width: theme.$form-fieldset-border-width;
     border-style: theme.$form-fieldset-border-style;
     border-color: theme.$form-fieldset-border-color;
@@ -29,6 +30,7 @@ main div form {
     legend {
       font-weight: theme.$form-fieldset-legend-font-weight;
       margin: theme.$form-fieldset-legend-margin;
+      padding: theme.$form-fieldset-legend-padding;
     }
 
     input {
@@ -38,6 +40,7 @@ main div form {
     /*Fieldsets within fieldsets ignore the "*" all selector */
     > fieldset {
       display: inline-block;
+      padding: theme.$form-fieldset-fields-padding;
       margin: theme.$form-fieldset-fields-margin;
       border-width: theme.$form-fieldset-border-width;
       border-style: theme.$form-fieldset-border-style;

--- a/manon/variables/_form-fieldset.scss
+++ b/manon/variables/_form-fieldset.scss
@@ -2,21 +2,24 @@
 $form-fieldset-border-width: null !default;
 $form-fieldset-border-style: null !default;
 $form-fieldset-border-color: null !default;
-$form-fieldset-padding: 0 !default;
+$form-fieldset-padding: null !default;
+$form-fieldset-margin: null !default;
 
 // Legend
-$form-fieldset-legend-font-weight: bold !default;
+$form-fieldset-legend-font-weight: null !default;
 $form-fieldset-legend-margin-bottom: null !default;
-$form-fieldset-legend-margin: 0 0 1rem 0 !default;
+$form-fieldset-legend-margin: null !default;
+$form-fieldset-legend-padding: null !default;
 
 // Nested fieldsets
+$form-fieldset-fields-padding: null !default;
 $form-fieldset-fields-margin: null !default;
 
 // Label
 $form-fieldset-label-margin: null !default;
 
 // Input
-$form-fieldset-input-margin: 0.5rem 0 1rem 0 !default;
+$form-fieldset-input-margin: null !default;
 
 // Nota bene
 $form-fieldset-nota-bene-padding-bottom: null !default;

--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -241,6 +241,15 @@ and spacing sets */
 
   // form fieldset
   $form-fieldset-border-width: 0,
+  $form-fieldset-padding: 0,
+  $form-fieldset-margin: 0,
+  $form-fieldset-legend-font-weight: bold,
+  $form-fieldset-legend-margin-bottom: null,
+  $form-fieldset-legend-margin: 0 0 1rem 0,
+  $form-fieldset-legend-padding: 0,
+  $form-fieldset-input-margin: 0.5rem 0 1rem 0,
+  $form-fieldset-fields-padding: 0,
+  $form-fieldset-fields-margin: 0,
 
   // form group
   $form-group-gap: spacing.$spacing-050,


### PR DESCRIPTION
- Move all fieldset variables to icore-open theme
- Fix aligment of fieldset by removing extra paddings and margins, also legend left padding.

Before:
<img width="568" height="358" alt="image" src="https://github.com/user-attachments/assets/9f361c2e-d121-4717-b6f0-5111e54da92b" />

After:
<img width="582" height="379" alt="image" src="https://github.com/user-attachments/assets/31ca5d8e-95c0-4490-813d-3f5f0fe29f83" />

