### PR TITLE
fix: small refactor of form horizontal scss

### DIFF
--- a/manon/components/form-horizontal.scss
+++ b/manon/components/form-horizontal.scss
@@ -30,7 +30,6 @@ form.horizontal {
     &.form-group {
       display: flex;
       flex-direction: row;
-      align-items: center;
       flex-wrap: nowrap;
       margin: 0;
       width: theme.$form-horizontal-group;

--- a/manon/variables/_form-horizontal.scss
+++ b/manon/variables/_form-horizontal.scss
@@ -12,5 +12,5 @@ $form-horizontal-button-margin: null !default;
 
 // Form group
 $form-horizontal-group-gap: null !default;
-$form-horizontal-group-align-items: null !default;
+$form-horizontal-group-align-items: center !default;
 $form-horizontal-group-justify-content: null !default;


### PR DESCRIPTION
- Cleaned up some css.  So grouped content within a horizontal form uses the group variables. 
- Removed the check by "apply-from-theme" as it's unnecessary 