### PR TITLE
fix: help input alignment

### DIFF
--- a/docs/src/routes/examples/pages/login/+page@.svelte
+++ b/docs/src/routes/examples/pages/login/+page@.svelte
@@ -27,29 +27,31 @@
     <h1>Inloggen</h1>
     <div class="content-wrapper">
       <form class="help">
-        <div>
+        <div class="help-container">
           <label for="username">Gebruikersnaam</label>
           <input id="username" name="username" placeholder="Gebruikersnaam" />
         </div>
 
         <div>
           <label for="password">Wachtwoord</label>
-          <input
-            id="password"
-            name="password"
-            placeholder="Wachtwoord"
-            type="password"
-            aria-describedby="password-message"
-          />
-          <p
-            class="explanation"
-            data-open-label="Toelichting bij het veld: Voorbeeld text input"
-            data-close-label="Sluit toelichting bij het veld: Voorbeeld text input"
-            id="password-message"
-          >
-            <span>Toelichting:</span> Wachtwoord moet minimaal 8 tekens bevatten waarvan minimaal 1 hoofdletter,
-            1 kleineletter en 1 cijfer.
-          </p>
+          <div class="help-container">
+            <input
+              id="password"
+              name="password"
+              placeholder="Wachtwoord"
+              type="password"
+              aria-describedby="password-message"
+            />
+            <p
+              class="explanation"
+              data-open-label="Toelichting bij het veld: Voorbeeld text input"
+              data-close-label="Sluit toelichting bij het veld: Voorbeeld text input"
+              id="password-message"
+            >
+              <span>Toelichting:</span> Wachtwoord moet minimaal 8 tekens bevatten waarvan minimaal 1 hoofdletter,
+              1 kleineletter en 1 cijfer.
+            </p>
+          </div>
         </div>
         <button type="submit">Inloggen</button>
       </form>

--- a/manon/components/form-help.scss
+++ b/manon/components/form-help.scss
@@ -8,6 +8,11 @@ form.help {
   > div {
     width: 100%;
     position: relative;
+    padding: theme.$form-help-container-padding;
+
+    &:has(.help-container) {
+      padding: 0;
+    }
   }
 
   .help-container {


### PR DESCRIPTION
Fixes alignment on input fields within a form with help texts.

Before: 
<img width="729" height="433" alt="Screenshot 2025-11-03 at 14 22 37" src="https://github.com/user-attachments/assets/87325beb-2f15-453d-a601-3fc9bf0edca4" />

After: 
<img width="701" height="433" alt="Screenshot 2025-11-03 at 14 22 19" src="https://github.com/user-attachments/assets/fdfb2c90-e723-4a30-964c-cf9e6f21b6d9" />
