### PR TITLE
Fix background image example

### DIFF
--- a/docs/src/routes/library/components/image/image-background/+page.md
+++ b/docs/src/routes/library/components/image/image-background/+page.md
@@ -23,13 +23,13 @@ SCSS importeren:
 
 ### Voorbeeld: div
 
-<div >
+<div>
   <h2>Lorem ipsum</h2>
   <img src="$img/strand.jpg" alt="Foto van een strand" class="image-background">
 </div>
 
 ```html
-<div class="image-background">
+<div>
   <h2>Lorem ipsum</h2>
   <img src="$img/strand.jpg" alt="Foto van een strand" class="image-background" />
 </div>

--- a/manon/components/image-background.scss
+++ b/manon/components/image-background.scss
@@ -12,17 +12,16 @@
   top: 0;
   left: 0;
   z-index: -1;
-
-  @include theming.apply-from-theme(
-    (
-      object-position: theme.$image-background-object-position,
-    )
-  );
+  object-position: theme.$image-background-object-position;
 }
 
 *:has(> .image-background) {
   position: relative;
   z-index: 0;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: theme.$image-background-elements-padding;
 }
 
 .image-background {

--- a/manon/variables/_image-background.scss
+++ b/manon/variables/_image-background.scss
@@ -1,1 +1,2 @@
 $image-background-object-position: null !default;
+$image-background-elements-padding: null !default;

--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -794,5 +794,9 @@ and spacing sets */
   $tile-group-padding: spacing.$spacing-100 0 0 0,
 
   // tile image
-  $tile-image-cover-margin-bottom: spacing.$spacing-100
+  $tile-image-cover-margin-bottom: spacing.$spacing-100,
+
+  // image background
+  $image-background-object-position: center,
+  $image-background-elements-padding: spacing.$spacing-150
 );


### PR DESCRIPTION
- Add dimension for cover image
- Add padding for inner elements in this case `<h2>` would not be at the edge.
- Select background image in theme as center aligned.

Before:
<img width="1041" height="480" alt="image" src="https://github.com/user-attachments/assets/979de232-cd57-45c0-8125-c7475455a8cb" />

After:
<img width="1041" height="562" alt="image" src="https://github.com/user-attachments/assets/594af7cc-18d5-4f19-8974-82ac96c86e00" />
