### PR TITLE
fix: adds spacing option within horizontal groups

### DIFF
--- a/manon/utility/horizontal.scss
+++ b/manon/utility/horizontal.scss
@@ -21,6 +21,15 @@ $breakpoint: 50rem !default;
   @extend %horizontal;
 }
 
-.horizontal-group > div {
-  @extend %horizontal;
+.horizontal-group {
+  @if theme.$horizontal-group-gap {
+    display: flex;
+    flex-direction: column;
+  }
+
+  gap: theme.$horizontal-group-gap;
+
+  > div {
+    @extend %horizontal;
+  }
 }

--- a/manon/variables/_horizontal.scss
+++ b/manon/variables/_horizontal.scss
@@ -1,2 +1,3 @@
 $horizontal-justify-content: null !default;
 $horizontal-gap: null !default;
+$horizontal-group-gap: null !default;

--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -493,6 +493,7 @@ and spacing sets */
 
   // utility
   $horizontal-gap: spacing.$spacing-100,
+  $horizontal-group-gap: spacing.$spacing-100,
 
   // icon
   $icon-height: 1.5rem,


### PR DESCRIPTION
Adds spacing option to horizontal groups

Before: 
<img width="196" height="116" alt="Screenshot 2025-11-13 at 11 24 41" src="https://github.com/user-attachments/assets/f831a572-19c3-4a75-b7cf-121a0f6ec063" />

After: 
<img width="200" height="136" alt="Screenshot 2025-11-13 at 11 24 21" src="https://github.com/user-attachments/assets/ab8f7c06-63cc-4d18-984b-39ef5ec0e58f" />
