### PR TITLE
fix: button link hover text color issue and icon button alignment

### DIFF
--- a/manon/components/button.scss
+++ b/manon/components/button.scss
@@ -2,6 +2,7 @@
 
 button,
 a.button,
+a.button:visited,
 input[type="button"],
 input[type="submit"],
 input[type="reset"] {

--- a/manon/components/link.scss
+++ b/manon/components/link.scss
@@ -10,6 +10,7 @@ a {
   span.icon {
     width: theme.$link-icon-width;
     height: theme.$link-icon-height;
+    min-width: theme.$link-icon-width;
     margin: theme.$link-icon-margin;
     padding: theme.$link-icon-padding;
     color: theme.$link-icon-color;


### PR DESCRIPTION
Fixes:
- Link buttons (a with class button) had an incorrect textcolor on visited links on hover. 
- Icon only link buttons weren't square. Due to the min-width not being set to the same width as the icon width.