### PR TITLE
Fix gap and negative margin

### DIFF
--- a/docs/src/scss/layout.scss
+++ b/docs/src/scss/layout.scss
@@ -5,7 +5,7 @@
   > h4,
   > h5,
   > h6 {
-    margin-bottom: -1rem;
+    margin-bottom: 0;
   }
 
   > section {
@@ -14,7 +14,7 @@
     > h4,
     > h5,
     > h6 {
-      margin-bottom: -1rem;
+      margin-bottom: 0;
     }
   }
 }

--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -78,7 +78,7 @@ and spacing sets */
   $article-content-wrapper-padding-bottom: spacing.$spacing-300,
   $article-content-wrapper-padding-left: spacing.$spacing-200,
   $article-content-wrapper-max-width: 60rem,
-  $article-content-wrapper-gap: spacing.$spacing-250,
+  $article-content-wrapper-gap: spacing.$spacing-150,
   $article-content-wrapper-flex-direction: column,
   $article-content-wrapper-border-radius: border-radii.$border-radius-m,
 

--- a/themes/kat/_index.scss
+++ b/themes/kat/_index.scss
@@ -322,8 +322,11 @@ and spacing sets */
   $section-padding-bottom: spacing.$spacing-100,
   $section-padding-left: 0,
   $section-max-width: 90rem,
-  $section-gap: spacing.$spacing-250,
+  $section-gap: spacing.$spacing-100,
   $section-flex-direction: column,
+
+  //article
+  $article-content-wrapper-gap: spacing.$spacing-100,
 
   // section content wrapper
   $section-content-wrapper-background-color: color-scheme.$white,


### PR DESCRIPTION
- Negative margin creates overlap of heading and paragraph.
- Fix the negative margin by reducing gaps

<img width="1097" height="381" alt="image" src="https://github.com/user-attachments/assets/704023d7-f502-4fae-b10e-35c27823429d" />
