### PR TITLE
fix: icon dimension collapsible

### DIFF
--- a/manon/mixins/collapsible.scss
+++ b/manon/mixins/collapsible.scss
@@ -22,8 +22,8 @@
       and its width adjusts automatically to maintain the correct aspect ratio. 
       */
       .icon {
-        height: 1em;
-        width: 1em;
+        height: theme.$collapsible-button-icon-height;
+        width: theme.$collapsible-button-icon-width;
       }
 
       + .collapsing-element {

--- a/manon/variables/_collapsible.scss
+++ b/manon/variables/_collapsible.scss
@@ -47,6 +47,10 @@ $collapsing-element-list-item-link-padding-left: 1rem !default;
 $collapsing-element-list-item-link-text-color: null !default;
 $collapsing-element-list-item-link-text-decoration: null !default;
 
+// Collapsing button icon
+$collapsible-button-icon-height: 1em !default;
+$collapsible-button-icon-width: 1em !default;
+
 // Collapsing element icon
 $collapsing-element-list-icon: null !default;
 $collapsing-element-list-icon-font-family: null !default;


### PR DESCRIPTION
Small fix so that it takes height and width according to collapsible text.

<img width="331" height="206" alt="image" src="https://github.com/user-attachments/assets/7bd3a735-9a8d-4948-b4fc-f077304b38b1" />
