### PR TITLE
Add default gap when its not defined

### DIFF
--- a/manon/variables/_button.scss
+++ b/manon/variables/_button.scss
@@ -12,7 +12,7 @@ $button-padding-right: null !default;
 $button-padding-bottom: null !default;
 $button-padding-left: null !default;
 $button-justify-content: null !default;
-$button-gap: null !default;
+$button-gap: 0.5rem !default;
 $button-line-height: null !default;
 $button-text-decoration: null !default;
 $button-text-align: null !default;


### PR DESCRIPTION
when no button gap is set, let is have at least a bit spacing.

<img width="387" height="254" alt="image" src="https://github.com/user-attachments/assets/acb872b5-ee2f-4e2e-9532-de1e4ca0f9cf" />
