### PR TITLE
Fix hero height scaling

### DIFF
--- a/manon/variables/_hero.scss
+++ b/manon/variables/_hero.scss
@@ -1,5 +1,5 @@
-$hero-min-height: null !default;
-$hero-height: null !default;
+$hero-min-height: 25rem !default;
+$hero-height: auto !default;
 $hero-max-height: null !default;
 $hero-width: null !default;
 $hero-max-width: null !default;

--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -446,7 +446,6 @@ and spacing sets */
   $h1-font-family: semantic.$font-family,
 
   // hero
-  $hero-height: 25rem,
   $hero-max-width: calc(100% + 8rem),
   $hero-width: calc(100% + 8rem),
   $hero-margin: -4rem 0 0 -4rem,

--- a/themes/kat/_index.scss
+++ b/themes/kat/_index.scss
@@ -233,7 +233,6 @@ and spacing sets */
   $header-content-wrapper-width: 100%,
 
   // hero
-  $hero-height: 25rem,
   $hero-border-radius: 0,
   $hero-font-size: body-text.$body-text-l,
   $hero-background-color: color-scheme.$violet-200,


### PR DESCRIPTION
Hero height does not auto scale.
- Fix height from fixed height to min-height

before:
<img width="966" height="658" alt="image" src="https://github.com/user-attachments/assets/b5fbdebf-471c-4c02-a1fb-8890ba693ddb" />

after:
<img width="1188" height="702" alt="image" src="https://github.com/user-attachments/assets/8918fd99-285f-451c-9539-3de053b2c6f2" />
