### PR TITLE
fix: button-container in KAT theme

### DIFF
--- a/docs/src/routes/library/components/button/button-container/+page.md
+++ b/docs/src/routes/library/components/button/button-container/+page.md
@@ -21,12 +21,12 @@ SCSS importeren:
 
 <div class="button-container">
   <button>Eerste knop</button>
-  <button>Tweede knop</button>
+  <button class="secondary">Tweede knop</button>
 </div>
 
 ```html
 <div class="button-container">
   <button>Eerste knop</button>
-  <button>Tweede knop</button>
+  <button class="secondary">Tweede knop</button>
 </div>
 ```

--- a/themes/kat/_index.scss
+++ b/themes/kat/_index.scss
@@ -101,6 +101,9 @@ and spacing sets */
   $button-secondary-focus-outline: 2px solid color-scheme.$violet-500,
   $button-secondary-focus-outline-offset: 0.25rem,
 
+  // button container
+  $button-container-gap: 1rem,
+
   // breadcrumb bar
   $breadcrumb-bar-padding-top: spacing.$spacing-050,
   $breadcrumb-bar-padding-right: spacing.$spacing-100,


### PR DESCRIPTION
- Fix gap between buttons
- Add an example of also a secondary button next to a primary button.

Before:
<img width="471" height="310" alt="image" src="https://github.com/user-attachments/assets/4c09fa49-d1cc-4cf4-8d4d-58144d306d99" />


After:
<img width="678" height="351" alt="image" src="https://github.com/user-attachments/assets/f3c3325e-8e37-4214-b7da-221ff78b297b" />
