### PR TITLE
fix: form spacing in KAT theme

### DIFF
--- a/themes/kat/_index.scss
+++ b/themes/kat/_index.scss
@@ -475,7 +475,7 @@ and spacing sets */
   $form-fieldset-input-margin: 0.5rem 0 1rem 0,
   $form-fieldset-fields-padding: 0,
   $form-fieldset-fields-margin: 0,
-    
+
   // nota bene
   $nota-bene-font-size: body-text.$body-text-s,
   $nota-bene-text-color: color-scheme.$grey-700


### PR DESCRIPTION
Fix spacing between elements in form

Before:
<img width="810" height="270" alt="image" src="https://github.com/user-attachments/assets/a38bc7c6-85a6-4baa-b915-f325ac0391a4" />

After:

<img width="828" height="423" alt="image" src="https://github.com/user-attachments/assets/af7a0d39-28fa-40db-9b96-1c8d141f8a04" />
