### PR TITLE
fix: accordion in KAT theme 

### DIFF
--- a/manon/components/accordion.scss
+++ b/manon/components/accordion.scss
@@ -11,6 +11,7 @@
   text-decoration: none;
   display: theme.$accordion-button-display;
   padding: theme.$accordion-button-padding;
+  font-family: theme.$accordion-button-font-family;
   font-size: theme.$accordion-button-font-size;
   font-weight: theme.$accordion-button-font-weight;
   justify-content: theme.$accordion-button-justify-content;

--- a/manon/variables/_accordion.scss
+++ b/manon/variables/_accordion.scss
@@ -11,6 +11,7 @@ $accordion-button-background-color: null !default;
 $accordion-button-border-width: null !default;
 $accordion-button-border-style: null !default;
 $accordion-button-border-color: null !default;
+$accordion-button-font-family: null !default;
 $accordion-button-font-size: null !default;
 $accordion-button-font-weight: null !default;
 $accordion-button-border-radius: null !default;

--- a/themes/kat/_index.scss
+++ b/themes/kat/_index.scss
@@ -32,6 +32,45 @@ and spacing sets */
 @use "@minvws/manon/variables" with (
   $theme-name: "kat",
 
+  // accordion
+  $accordion-gap: spacing.$spacing-100,
+  $accordion-button-padding: spacing.$spacing-075 spacing.$spacing-100,
+  $accordion-button-text-color: color-scheme.$blue-600,
+  $accordion-button-background-color: color-scheme.$white,
+  $accordion-button-border-width: 0 0 1px 0,
+  $accordion-button-border-style: solid,
+  $accordion-button-border-color: color-scheme.$grey-200,
+  $accordion-button-font-weight: bold,
+  $accordion-button-font-family: semantic.$font-family,
+  $accordion-button-font-size: body-text.$body-text-m,
+  $accordion-content-border-width: 0,
+  $accordion-content-border-style: solid,
+  $accordion-content-border-color: color-scheme.$grey-200,
+  $accordion-content-padding: spacing.$spacing-100,
+  $accordion-content-gap: spacing.$spacing-050,
+  $accordion-content-font-size: body-text.$body-text-m,
+  $accordion-button-border-radius: border-radii.$border-radius-s
+    border-radii.$border-radius-s,
+  $accordion-content-border-radius: 0 0 border-radii.$border-radius-s
+    border-radii.$border-radius-s,
+  $accordion-expanded-button-border-radius: border-radii.$border-radius-s
+    border-radii.$border-radius-s 0 0,
+
+  // accordion icon open
+  $accordion-button-icon-before-color: color-scheme.$blue-600,
+  $accordion-button-icon-before-mask: map.get(icons.$icon-map, "chevron-down"),
+  $accordion-button-icon-before-width: 1.5rem,
+  $accordion-button-icon-before-height: 1.5rem,
+
+  // accordion icon closed
+  $accordion-button-icon-before-closed-color: color-scheme.$blue-600,
+  $accordion-button-icon-before-closed-mask: map.get(
+      icons.$icon-map,
+      "chevron-up"
+    ),
+  $accordion-button-icon-before-closed-width: 1.5rem,
+  $accordion-button-icon-before-closed-height: 1.5rem,
+
   // article
   $article-gap: spacing.$spacing-200,
 


### PR DESCRIPTION
Fix styling according to theme design for accordion:
<img width="580" height="506" alt="image" src="https://github.com/user-attachments/assets/0ba4274e-f146-4fba-9bd6-f57e358da578" />

Before:
<img width="1115" height="399" alt="image" src="https://github.com/user-attachments/assets/b4066922-4123-4a1b-bcb7-bac70f8f2107" />

After:
<img width="1071" height="557" alt="image" src="https://github.com/user-attachments/assets/acc9ce10-9ccb-4a04-bc66-89a8296b5e06" />

<img width="1073" height="233" alt="image" src="https://github.com/user-attachments/assets/ef1cb86b-ceae-49e7-ba04-e4c842b3aaef" />
