### PR TITLE
fix(visreg): improve visual regression test reliability with `waitUntil: load`

### DIFF
--- a/visreg/playwright/tests/visual-regression.test.js
+++ b/visreg/playwright/tests/visual-regression.test.js
@@ -6,9 +6,9 @@ for (const endpoint of endpoints) {
   const sanitizedEndpoint = endpoint.replace(/^\/|\/$/g, "") || "homepage";
 
   test(`Visual regression for: ${endpoint}`, async ({ page }) => {
-    // Go to the specified endpoint, and wait for the page to load
-    await page.goto(endpoint);
-    await page.waitForTimeout(1000);
+    // Go to the specified endpoint, and wait for all the resources (images,
+    // stylesheets, scripts, iframes, and fonts) to load
+    await page.goto(endpoint, { waitUntil: "load" });
 
     await expect(page).toHaveScreenshot(`${sanitizedEndpoint}.png`, {
       fullPage: true,


### PR DESCRIPTION
We saw some inconsistencies while the visual regression test were running in the CI. (https://github.com/minvws/nl-rdo-manon/actions/runs/20487150887/job/58871792779)

This is likely caused by `page.waitForTimeOut(1000)`, which its usage is discouraged (https://playwright.dev/docs/api/class-page#page-wait-for-timeout).

An alternative `await page.goto(endpoint, { waitUntil: "load" });` should wait until all the resources on the page have loaded. Since we're testing for visual regressions this seems to be the most straightforward solution.
