### PR TITLE
fix: search bar height in header (rijkshuisstijl)

### DIFF
--- a/manon/components/form-input.scss
+++ b/manon/components/form-input.scss
@@ -23,3 +23,21 @@ input {
     cursor: not-allowed;
   }
 }
+
+header input {
+  padding-top: theme.$form-input-header-padding-top;
+  padding-right: theme.$form-input-header-padding-right;
+  padding-bottom: theme.$form-input-header-padding-bottom;
+  padding-left: theme.$form-input-header-padding-left;
+  background-color: theme.$form-input-header-background-color;
+  color: theme.$form-input-header-text-color;
+  font-family: theme.$form-input-header-font-family;
+  font-size: theme.$form-input-header-font-size;
+  line-height: theme.$form-input-header-line-height;
+  font-weight: theme.$form-input-header-font-weight;
+  min-height: theme.$form-input-header-min-height;
+  border-width: theme.$form-input-header-border-width;
+  border-style: theme.$form-input-header-border-style;
+  border-color: theme.$form-input-header-border-color;
+  border-radius: theme.$form-input-header-border-radius;
+}

--- a/manon/variables/_form-input.scss
+++ b/manon/variables/_form-input.scss
@@ -14,3 +14,21 @@ $form-input-border-style: null !default;
 $form-input-border-color: null !default;
 $form-input-border-radius: null !default;
 $form-input-column: null !default;
+
+// form input within the header of a page
+$form-input-header-padding-top: null !default;
+$form-input-header-padding-right: null !default;
+$form-input-header-padding-bottom: null !default;
+$form-input-header-padding-left: null !default;
+$form-input-header-background-color: null !default;
+$form-input-header-text-color: null !default;
+$form-input-header-font-family: null !default;
+$form-input-header-font-size: null !default;
+$form-input-header-line-height: null !default;
+$form-input-header-font-weight: null !default;
+$form-input-header-min-height: 0 !default;
+$form-input-header-border-width: null !default;
+$form-input-header-border-style: null !default;
+$form-input-header-border-color: null !default;
+$form-input-header-border-radius: null !default;
+$form-input-header-column: null !default;

--- a/themes/rijkshuisstijl-2008/_index.scss
+++ b/themes/rijkshuisstijl-2008/_index.scss
@@ -333,6 +333,7 @@
   $form-input-border-color: color-scheme.$ro-blue,
   $form-input-font-size: inherit,
   $form-input-background-color: color-scheme.$white,
+  $form-input-header-border-width: 0,
 
   // Form horizontal
   $form-horizontal-view-fieldset-label-column: 33.33%,


### PR DESCRIPTION
Adds header form styling options and styling for input field within forms within Rijkshuisstijl. 

Fixes issue where search fields (input) and search button visually have different heights.

Before: 
<img width="919" height="262" alt="Screenshot 2026-04-09 at 20 00 49" src="https://github.com/user-attachments/assets/fee39c97-243b-4d81-ba06-0737ed8da045" />

After: 
<img width="966" height="231" alt="Screenshot 2026-04-09 at 20 00 34" src="https://github.com/user-attachments/assets/c84e297d-5796-42ea-9815-715bc9eca8db" />

note: Added all styling options for consistency. 
