### PR TITLE
Fixes navigation item layout

### DIFF
--- a/manon/components/breadcrumb-bar.scss
+++ b/manon/components/breadcrumb-bar.scss
@@ -130,6 +130,11 @@
           // Removing any generic nav icons
           display: none;
         }
+
+        // Removing styling used to keep navigation icons and item text on the same line
+        a {
+          max-width: unset;
+        }
       }
     }
   }

--- a/manon/components/header.scss
+++ b/manon/components/header.scss
@@ -121,6 +121,11 @@ body > header,
         /* Preventing default nav before to show up */
         display: none;
       }
+
+      // Removing styling used to keep navigation icons and item text on the same line
+      a {
+        max-width: unset;
+      }
     }
   }
 

--- a/manon/components/navigation.scss
+++ b/manon/components/navigation.scss
@@ -9,6 +9,7 @@
     border-style: theme.$navigation-link-border-style;
     border-color: theme.$navigation-link-border-color;
     border-radius: theme.$navigation-link-border-radius;
+    word-break: theme.$navigation-link-word-break;
 
     // Outline
     outline: theme.$navigation-link-outline;
@@ -84,6 +85,10 @@ nav {
           mask-image: theme.$navigation-list-item-icon-mask;
           width: theme.$navigation-list-item-icon-width;
           height: theme.$navigation-list-item-icon-height;
+        }
+
+        a {
+          max-width: theme.$navigation-list-item-link-max-width;
         }
       }
     }

--- a/manon/variables/_navigation.scss
+++ b/manon/variables/_navigation.scss
@@ -48,6 +48,7 @@ $navigation-link-text-color: null !default;
 $navigation-link-hover-text-color: null !default;
 $navigation-link-visited-text-color: null !default;
 $navigation-link-visited-hover-text-color: null !default;
+$navigation-link-word-break: null !default;
 
 // Outline
 $navigation-link-outline: null !default;
@@ -55,3 +56,6 @@ $navigation-link-outline-offset: null !default;
 $navigation-link-outline-color: null !default;
 $navigation-link-z-index: null !default;
 $navigation-link-box-shadow: null !default;
+
+// Link within list
+$navigation-list-item-link-max-width: null !default;

--- a/themes/rijkshuisstijl-2008/_index.scss
+++ b/themes/rijkshuisstijl-2008/_index.scss
@@ -563,6 +563,8 @@
   $navigation-list-gap: spacing.$spacing-025,
   $navigation-list-horizontal-gap: spacing.$spacing-100,
   $navigation-list-horizontal-item-icon-padding: 0,
+  $navigation-list-item-link-max-width: 85%,
+  $navigation-link-word-break: break-word,
 
   // Notification
   $notification-padding-top: spacing.$spacing-100,


### PR DESCRIPTION
Solves an issue where nav list icon and text are placed on separate lines. And adds the option to break long words within navigation items. 

Before: 
<img width="251" height="258" alt="Screenshot 2026-04-09 at 20 51 57" src="https://github.com/user-attachments/assets/7b0a4f0b-1a83-46b4-8520-7c1206ff9130" />


After: 
<img width="247" height="234" alt="Screenshot 2026-04-09 at 20 51 52" src="https://github.com/user-attachments/assets/bfa25f64-e736-4cb8-a4ed-78be08608c44" />

