### PR TITLE
fix: logo max width

### DIFF
--- a/manon/components/logo.scss
+++ b/manon/components/logo.scss
@@ -13,6 +13,7 @@
   white-space: theme.$logo-white-space;
   gap: theme.$logo-gap;
   width: theme.$logo-width;
+  max-width: theme.$logo-max-width;
   height: theme.$logo-height;
   margin: theme.$logo-margin;
   font-size: theme.$logo-font-size;

--- a/manon/variables/_logo.scss
+++ b/manon/variables/_logo.scss
@@ -6,6 +6,7 @@ $logo-align-self: center !default;
 $logo-white-space: null !default;
 $logo-gap: null !default;
 $logo-width: null !default;
+$logo-max-width: null !default;
 $logo-height: null !default;
 $logo-margin: null !default;
 $logo-font-size: null !default;

--- a/themes/rijkshuisstijl-2008/_index.scss
+++ b/themes/rijkshuisstijl-2008/_index.scss
@@ -678,6 +678,7 @@
   $logo-img-margin: 0 0 0 calc(50% - 1.25rem),
   $logo-img-object-fit: contain,
   $logo-width: 40rem,
+  $logo-max-width: 100%,
 
   $logo-font-size: body-text.$body-text-s,
   $logo-breakpoint-1-font-size: body-text.$body-text-m,


### PR DESCRIPTION
- adds logo styling options
- fixes logo max width in rijkshuisstijl preventing text from running out of the screen (and changing the layout of the page
