### PR TITLE
fix: icore open theme, hero contrast

### DIFF
--- a/themes/icore-open/_index.scss
+++ b/themes/icore-open/_index.scss
@@ -464,7 +464,7 @@
   $hero-margin: -4rem 0 0 -4rem,
   $hero-border-radius: 0,
   $hero-font-size: body-text.$body-text-l,
-  $hero-background-color: color-scheme.$oc-blue-6,
+  $hero-background-color: color-scheme.$oc-blue-8,
   $hero-justify-content: center,
   $hero-flex-direction: column,
   $hero-title-font-size: heading.$heading-xxl,


### PR DESCRIPTION
Fixes contrast within the icore open hero to comply with wcag 2.2 guidelines.