### PR TITLE
ci: update github actions and enable npm provenance

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,10 +13,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         cache: pnpm
         node-version-file: ".nvmrc"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,9 @@ jobs:
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +41,7 @@ jobs:
           pnpm --recursive npm-version --no-git-tag-version ${{ env.RELEASE_VERSION }}
           pnpm --recursive publish --no-git-checks --access public --tag ${{ env.NPM_TAG }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
   publish-github:
     name: Publish to GitHub


### PR DESCRIPTION
Migrates npm publishing from `NPM_TOKEN` authentication to GitHub Actions OIDC Trusted Publisher.

## Changes

- `permissions: id-token: write` allows this workflow to request an OpenID Connect (OIDC) identity token from GitHub.
- `NPM_CONFIG_PROVENANCE=true` attaches a cryptographic signature to this published package showing where it was built.
- upgraded `uses: pnpm/action-setup@v6` and `uses: actions/setup-node@v6` because of deprecation warnings
