### PR TITLE
fix: Removed unnecessary whitespace within sidemenu. (Theme: Rijkshuisstijl 2008)

### DIFF
--- a/manon/components/sidemenu.scss
+++ b/manon/components/sidemenu.scss
@@ -4,7 +4,7 @@ body.sidemenu,
 .manon-root.sidemenu,
 main.sidemenu {
   $sidemenu-width: theme.$sidemenu-nav-width;
-  $sidemenu-breakpoint: 50rem !default;
+  $sidemenu-breakpoint: 25rem !default;
 
   /* Places sidemenu next to the main content of the page */
   display: flex;
@@ -127,6 +127,15 @@ main.sidemenu {
       /* Needed to keep the button to stick to the top */
       top: theme.$sidemenu-button-margin-top;
       margin-left: theme.$sidemenu-button-margin-left;
+
+      margin-bottom: calc(theme.$sidemenu-nav-gap * -1);
+
+      @if theme.$sidemenu-button-min-height {
+        margin-bottom: calc(
+          (theme.$sidemenu-nav-gap + theme.$sidemenu-button-min-height) * -1
+        );
+      }
+
       min-width: theme.$sidemenu-button-min-width;
       min-height: theme.$sidemenu-button-min-height;
       font-size: theme.$sidemenu-button-font-size;

--- a/themes/rijkshuisstijl-2008/_index.scss
+++ b/themes/rijkshuisstijl-2008/_index.scss
@@ -803,6 +803,7 @@
   $sidemenu-button-font-size: 0,
   $sidemenu-button-margin-left: 0,
   $sidemenu-button-breakpoint-margin-left: 18rem,
+  $sidemenu-button-min-height: 1.25rem,
 
   // sidemenu expanded
   $sidemenu-expanded-icon-mask: map.get(icons.$icon-map, "close", "url"),


### PR DESCRIPTION
Removes unnecessary whitespace at the top of sidemenu in Rijkshuisstijl 2008.

Before: 
<img width="1215" height="943" alt="Screenshot 2026-06-30 at 09 08 07" src="https://github.com/user-attachments/assets/f2aada3a-d750-4203-bc92-1fcdc82cd86a" />

After: 
<img width="1214" height="870" alt="Screenshot 2026-06-30 at 09 07 48" src="https://github.com/user-attachments/assets/09141b56-015d-46ba-bbe2-f1164acde635" />

