### PR TITLE
fix: improved accessibility on table headers with a select all checkbox

### DIFF
--- a/docs/src/routes/library/components/table/table-checkbox/+page.md
+++ b/docs/src/routes/library/components/table/table-checkbox/+page.md
@@ -35,7 +35,7 @@ SCSS importeren:
             <th scope="col">
               <span class="visually-hidden">Selectie</span>
               <div class="checkbox">
-                <input type="checkbox" id="checkbox-example-head-1" name="standaard-checkbox" />
+                <input type="checkbox" id="checkbox-example-head-1" name="standaard-checkbox" aria-label="Select all rows in this table" />
               </div>
             </th>
             <th scope="col">Naam</th>
@@ -108,7 +108,12 @@ Complete voorbeeld tabel:
           <th scope="col">
             <span class="visually-hidden">Selectie</span>
             <div class="checkbox">
-              <input type="checkbox" id="checkbox-example-head-1" name="standaard-checkbox" />
+              <input
+                type="checkbox"
+                id="checkbox-example-head-1"
+                name="standaard-checkbox"
+                aria-label="Select all rows in this table"
+              />
             </div>
           </th>
           <th scope="col">Naam</th>


### PR DESCRIPTION
Improves a11y within table header with a select all checkbox. 
Adds a description for screenreader users to explain the function of the checkbox. e.g Select all rows within this table.

Closes: 
https://github.com/minvws/nl-rdo-manon/issues/1405