### PR TITLE
fix: improved a11y on expando row

### DIFF
--- a/docs/src/routes/library/components/table/table-expando-row/+page.md
+++ b/docs/src/routes/library/components/table/table-expando-row/+page.md
@@ -49,7 +49,7 @@ import "@minvws/manon/js/expando-rows.js";
     </thead>
     <tbody>
       <tr>
-        <td>Security overzicht Maart</td>
+        <th>Security overzicht Maart</th>
         <td>Audit</td>
         <td>Project A</td>
         <td>03-04-2025</td>
@@ -90,7 +90,7 @@ import "@minvws/manon/js/expando-rows.js";
         </td>
       </tr>
       <tr>
-        <td>Toegankelijkheidsrapport</td>
+        <th>Toegankelijkheidsrapport</th>
         <td>Audit</td>
         <td>Project B</td>
         <td>12-02-2025</td>
@@ -138,23 +138,23 @@ import "@minvws/manon/js/expando-rows.js";
 <div class="horizontal-scroll">
   <table>
     <caption>
-      Voorbeeld uitklapbare tabelrijen:
+      Rapportage-overzicht:
     </caption>
     <thead>
       <tr>
-        <th scope="col">Risicolevel</th>
-        <th scope="col">Bevindingstype</th>
-        <th scope="col">Hoeveelheid</th>
-        <th scope="col">Status</th>
+        <th scope="col">Naam</th>
+        <th scope="col">Type</th>
+        <th scope="col">Project</th>
+        <th scope="col">Datum</th>
         <th scope="col">Details</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><span class="critical">Critical</span></td>
-        <td>Lorem ipsum dolor sit</td>
-        <td class="number">4</td>
-        <td>New</td>
+        <th>Security overzicht Maart</th>
+        <td>Audit</td>
+        <td>Project A</td>
+        <td>03-04-2025</td>
         <td>
           <button
             class="expando-button"
@@ -169,18 +169,36 @@ import "@minvws/manon/js/expando-rows.js";
       </tr>
       <tr class="expando-row">
         <td colspan="5">
-          <h2>Extra informatie</h2>
-          <p>
-            Hier vindt u aanvullende informatie die betrekking heeft op deze rij. U kunt hier
-            context, toelichtingen of andere relevante details opnemen.
-          </p>
+          <div class="expando-row-content">
+            <div>
+              <h2 class="heading-xs">Onderzoeksdetails</h2>
+              <dl>
+                <div>
+                  <dt>Uitgevoerende partij</dt>
+                  <dd>Partij A</dd>
+                </div>
+                <div>
+                  <dt>Datum</dt>
+                  <dd>31-3-2025</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>Afgerond</dd>
+                </div>
+              </dl>
+            </div>
+            <p class="nota-bene">
+              Dit onderzoek is uitvoerd in opdracht door het ministerie van volksgezondheid welzijn
+              en sport
+            </p>
+          </div>
         </td>
       </tr>
       <tr>
-        <td><span class="high">High</span></td>
-        <td>Lorem ipsum dolor sit</td>
-        <td class="number">12</td>
-        <td>New</td>
+        <th>Toegankelijkheidsrapport</th>
+        <td>Audit</td>
+        <td>Project B</td>
+        <td>12-02-2025</td>
         <td>
           <button
             class="expando-button"
@@ -195,11 +213,29 @@ import "@minvws/manon/js/expando-rows.js";
       </tr>
       <tr class="expando-row">
         <td colspan="5">
-          <h2>Extra informatie</h2>
-          <p>
-            Hier vindt u aanvullende informatie die betrekking heeft op deze rij. U kunt hier
-            context, toelichtingen of andere relevante details opnemen.
-          </p>
+          <div class="expando-row-content">
+            <div>
+              <h2 class="heading-xs">Onderzoeksdetails</h2>
+              <dl>
+                <div>
+                  <dt>Uitgevoerende partij</dt>
+                  <dd>Partij A</dd>
+                </div>
+                <div>
+                  <dt>Datum</dt>
+                  <dd>31-3-2025</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>Afgerond</dd>
+                </div>
+              </dl>
+            </div>
+            <p class="nota-bene">
+              Dit onderzoek is uitvoerd in opdracht door het ministerie van volksgezondheid welzijn
+              en sport
+            </p>
+          </div>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Improved a11y on expando row. Added table headers within rows to improve clarity on the relation between the data.

Closes: 
https://github.com/minvws/nl-rdo-manon/issues/415