### PR TITLE
fix: Improved language selector accessibility and added tests

### DIFF
--- a/docs/src/routes/library/components/language-selector/+page.md
+++ b/docs/src/routes/library/components/language-selector/+page.md
@@ -30,12 +30,14 @@ import "@minvws/manon/js/language-selector.js";
 
 <div class="language-selector">
   <p id="language-selector-description">Kies een taal:</p>
-  <div
-    class="language-selector-options"
-    aria-expanded="false"
-  >
-    <button aria-haspopup="listbox" aria-current="true" aria-describedby="language-selector-description"> Papiamentu </button>
-    <ul role="listbox">
+  <div class="language-selector-options">
+    <button
+      aria-haspopup="listbox"
+      aria-expanded="false"
+      aria-controls="language-selector-list"
+      aria-describedby="language-selector-description"
+    > Papiamentu </button>
+    <ul id="language-selector-list" role="listbox">
       <li role="option" aria-selected="false">
         <a hreflang="nl" href="language-selector" data-value="Nederlands" lang="nl"
           >Nederlands</a
@@ -64,15 +66,16 @@ import "@minvws/manon/js/language-selector.js";
 ```html
 <div class="language-selector">
   <p id="language-selector-description">Kies een taal:</p>
-  <div class="language-selector-options" aria-expanded="false">
+  <div class="language-selector-options">
     <button
       aria-haspopup="listbox"
-      aria-current="true"
+      aria-expanded="false"
+      aria-controls="language-selector-list"
       aria-describedby="language-selector-description"
     >
       Papiamentu
     </button>
-    <ul role="listbox">
+    <ul id="language-selector-list" role="listbox">
       <li role="option" aria-selected="false">
         <a hreflang="nl" href="#" data-value="Nederlands" lang="nl">Nederlands</a>
       </li>

--- a/manon/components/language-selector.scss
+++ b/manon/components/language-selector.scss
@@ -24,6 +24,7 @@ body > header nav .language-selector,
   }
 
   ul {
+    display: none;
     position: static;
     padding: 0;
     margin: 0;
@@ -120,28 +121,18 @@ body > header nav .language-selector,
     }
   }
 
-  /* Hide option list */
-  div[aria-expanded="false"] {
-    ul,
-    ul li {
-      display: none;
-    }
-  }
-
   /* Expand option list */
-  div[aria-expanded="true"] {
-    ul {
+  button[aria-expanded="true"] + ul {
+    display: block;
+    position: absolute;
+
+    li {
       display: block;
-      position: absolute;
 
-      li {
-        display: block;
-
-        /* Selected language */
-        &[aria-current="true"] {
-          a {
-            cursor: default;
-          }
+      /* Selected language */
+      &[aria-current="true"] {
+        a {
+          cursor: default;
         }
       }
     }
@@ -189,13 +180,13 @@ body > header nav .language-selector,
       }
     }
 
-    &[aria-expanded="true"] > button {
+    > button[aria-expanded="true"] {
       &::after {
         content: theme.$language-selector-list-closed-button-icon;
       }
     }
 
-    &[aria-expanded="false"] > button {
+    > button[aria-expanded="false"] {
       &::after {
         content: theme.$language-selector-list-open-button-icon;
       }

--- a/manon/js/language-selector.js
+++ b/manon/js/language-selector.js
@@ -15,6 +15,42 @@ export function initLanguageSelector() {
 }
 
 /**
+ * Returns the button that expands and collapses the list of languages.
+ *
+ * @param {Element} el
+ * @returns {HTMLButtonElement | null}
+ */
+function getSelectorButton(el) {
+  return el.querySelector(":scope > button");
+}
+
+/**
+ * @param {HTMLElement} btn
+ * @param {boolean} expanded
+ */
+function setExpanded(btn, expanded) {
+  btn.setAttribute("aria-expanded", expanded ? "true" : "false");
+}
+
+/**
+ * @param {HTMLElement} btn
+ * @returns {boolean}
+ */
+function isExpanded(btn) {
+  return btn.getAttribute("aria-expanded") === "true";
+}
+
+/**
+ * Give focus to the language within the given list item.
+ *
+ * @param {Element | null} listItem
+ */
+function focusOption(listItem) {
+  const option = listItem?.querySelector("a");
+  if (option instanceof HTMLElement) option.focus();
+}
+
+/**
  * @param {Event} event
  */
 function onClick(event) {
@@ -24,12 +60,10 @@ function onClick(event) {
   );
   if (!languageSelectorElement) return;
 
-  const expanded =
-    languageSelectorElement.getAttribute("aria-expanded") === "true";
-  languageSelectorElement.setAttribute(
-    "aria-expanded",
-    expanded ? "false" : "true"
-  );
+  const selectorButton = getSelectorButton(languageSelectorElement);
+  if (!selectorButton) return;
+
+  setExpanded(selectorButton, !isExpanded(selectorButton));
 }
 
 /**
@@ -42,11 +76,10 @@ function onKeyPress(event) {
     ".language-selector-options"
   );
   if (!languageSelectorElement) return;
-  const expanded =
-    languageSelectorElement.getAttribute("aria-expanded") === "true";
+  const selectorButton = getSelectorButton(languageSelectorElement);
+  if (!selectorButton) return;
+  const expanded = isExpanded(selectorButton);
   const listLength = languageSelectorElement.getElementsByTagName("li").length;
-  const selectorButton =
-    languageSelectorElement.getElementsByTagName("button")[0];
   const firstOption =
     languageSelectorElement.querySelector("li:first-of-type a");
   const lastOption = languageSelectorElement.querySelector("li:last-of-type a");
@@ -56,24 +89,18 @@ function onKeyPress(event) {
   if (selectorButton === document.activeElement) {
     switch (event.code) {
       case "Enter":
-        languageSelectorElement.setAttribute(
-          "aria-expanded",
-          expanded ? "false" : "true"
-        );
+        setExpanded(selectorButton, !expanded);
         event.preventDefault();
         break;
       case "Space":
-        languageSelectorElement.setAttribute(
-          "aria-expanded",
-          expanded ? "false" : "true"
-        );
+        setExpanded(selectorButton, !expanded);
         event.preventDefault();
         break;
       case "Escape":
-        languageSelectorElement.setAttribute("aria-expanded", "false");
+        setExpanded(selectorButton, false);
         break;
       case "ArrowUp":
-        languageSelectorElement.setAttribute("aria-expanded", "true");
+        setExpanded(selectorButton, true);
         languageSelectorElement
           .getElementsByTagName("li")
           [listLength - 1].getElementsByTagName("a")[0]
@@ -81,7 +108,7 @@ function onKeyPress(event) {
         event.preventDefault();
         break;
       case "ArrowDown":
-        languageSelectorElement.setAttribute("aria-expanded", "true");
+        setExpanded(selectorButton, true);
         firstOption.focus();
         event.preventDefault();
         break;
@@ -92,15 +119,25 @@ function onKeyPress(event) {
 
   // If the element that has focus is a decendent of the language selector element.
   if (languageSelectorElement.contains(document.activeElement)) {
-    const focusParent = document.activeElement;
-    if (!(focusParent instanceof HTMLElement)) return;
+    const focusedOption = document.activeElement;
+    if (!(focusedOption instanceof HTMLElement)) return;
+    // Go up from the focused element -> <a> to its <li>, so its siblings are the other languages.
+    const focusedItem = focusedOption.closest("li");
+    if (!focusedItem) return;
     switch (event.code) {
       // If the ESCAPE key is pressed.
       case "Escape":
         // Give focus to the selector button.
         selectorButton.focus();
         // Close the drop down.
-        languageSelectorElement.setAttribute("aria-expanded", "false");
+        setExpanded(selectorButton, false);
+        break;
+      // On SPACE key, select the focused language
+      case "Space":
+        if (focusedOption instanceof HTMLAnchorElement) {
+          focusedOption.click();
+          event.preventDefault();
+        }
         break;
       // If the UP key is pressed.
       case "ArrowUp":
@@ -108,10 +145,7 @@ function onKeyPress(event) {
           // Stop the script if the focus is on the first element.
           break;
         }
-        // Target the currently focused element -> <a>, go up a node -> <li>, select the previous sibling of the previous sibling and the a-node within and focus it.
-        focusParent.previousElementSibling
-          ?.getElementsByTagName("a")[0]
-          .focus();
+        focusOption(focusedItem.previousElementSibling);
         event.preventDefault();
         break;
       // If the DOWN key is pressed.
@@ -120,8 +154,7 @@ function onKeyPress(event) {
           // Stop the script if the focus is on the last element.
           break;
         }
-        // Target the currently focused element -> <a>, go up a node -> <li>, select the next sibling of the next sibling and the a-node within and focus it.
-        focusParent.nextElementSibling?.getElementsByTagName("a")[0].focus();
+        focusOption(focusedItem.nextElementSibling);
         event.preventDefault();
         break;
     }

--- a/manon/tests/language-selector.test.js
+++ b/manon/tests/language-selector.test.js
@@ -1,0 +1,153 @@
+import { expect, test } from "vitest";
+import { getByRole } from "@testing-library/dom";
+import { render } from "../vitest.setup.js";
+
+import { initLanguageSelector } from "../js/language-selector.js";
+
+function renderLanguageSelector() {
+  const result = render(`
+    <div class="language-selector">
+      <p id="language-selector-description">Kies een taal:</p>
+      <div class="language-selector-options">
+        <button
+          aria-haspopup="listbox"
+          aria-expanded="false"
+          aria-controls="language-selector-list"
+          aria-describedby="language-selector-description"
+        >
+          Papiamentu
+        </button>
+        <ul id="language-selector-list" role="listbox">
+          <li role="option" aria-selected="false">
+            <a hreflang="nl" href="#" lang="nl">Nederlands</a>
+          </li>
+          <li role="option" aria-selected="false">
+            <a hreflang="en" href="#" lang="en">English</a>
+          </li>
+          <li role="option" aria-selected="true" aria-current="true">
+            <a hreflang="pap-CW" href="#" lang="pap-CW">Papiamentu</a>
+          </li>
+        </ul>
+      </div>
+    </div>`);
+
+  initLanguageSelector();
+
+  return {
+    ...result,
+    button: getByRole(result.container, "button"),
+    wrapper: result.container.querySelector(".language-selector-options"),
+    languages: /** @type {HTMLAnchorElement[]} */ (
+      Array.from(result.container.querySelectorAll("li a"))
+    ),
+  };
+}
+
+test("reports the collapsed state on the button, not on the wrapper", () => {
+  const { button, wrapper } = renderLanguageSelector();
+
+  expect(button).toHaveAttribute("aria-expanded", "false");
+  expect(button).toHaveAttribute("aria-controls", "language-selector-list");
+  expect(wrapper).not.toHaveAttribute("aria-expanded");
+});
+
+test("toggles the list when the button is clicked", async () => {
+  const { button, user } = renderLanguageSelector();
+
+  await user.click(button);
+  expect(button).toHaveAttribute("aria-expanded", "true");
+
+  await user.click(button);
+  expect(button).toHaveAttribute("aria-expanded", "false");
+});
+
+test.each([["{Enter}"], ["{ }"]])(
+  "toggles the list when %s is pressed on the button",
+  async (key) => {
+    const { button, user } = renderLanguageSelector();
+
+    button.focus();
+    await user.keyboard(key);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard(key);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  }
+);
+
+test("treats a button without aria-expanded as collapsed", async () => {
+  const { container, user } = render(`
+    <div class="language-selector">
+      <div class="language-selector-options">
+        <button aria-haspopup="listbox">Papiamentu</button>
+        <ul role="listbox">
+          <li role="option"><a hreflang="nl" href="#" lang="nl">Nederlands</a></li>
+        </ul>
+      </div>
+    </div>`);
+
+  initLanguageSelector();
+
+  const button = getByRole(container, "button");
+  await user.click(button);
+
+  expect(button).toHaveAttribute("aria-expanded", "true");
+});
+
+test("opens downwards to the first language and stops at the top", async () => {
+  const { button, languages, user } = renderLanguageSelector();
+  const [dutch, english] = languages;
+
+  button.focus();
+  await user.keyboard("{ArrowDown}");
+  expect(button).toHaveAttribute("aria-expanded", "true");
+  expect(dutch).toHaveFocus();
+
+  await user.keyboard("{ArrowDown}");
+  expect(english).toHaveFocus();
+
+  await user.keyboard("{ArrowUp}");
+  expect(dutch).toHaveFocus();
+
+  // Top of the list, so focus stays put
+  await user.keyboard("{ArrowUp}");
+  expect(dutch).toHaveFocus();
+});
+
+test("opens upwards to the last language and stops at the bottom", async () => {
+  const { button, languages, user } = renderLanguageSelector();
+  const papiamentu = languages[languages.length - 1];
+
+  button.focus();
+  await user.keyboard("{ArrowUp}");
+  expect(button).toHaveAttribute("aria-expanded", "true");
+  expect(papiamentu).toHaveFocus();
+
+  await user.keyboard("{ArrowDown}");
+  expect(papiamentu).toHaveFocus();
+});
+
+test("selects the focused language when Space is pressed", async () => {
+  const { languages, user } = renderLanguageSelector();
+  const [dutch] = languages;
+  let followed = 0;
+  dutch.addEventListener("click", (event) => {
+    followed++;
+    event.preventDefault();
+  });
+
+  dutch.focus();
+  await user.keyboard("{ }");
+
+  expect(followed).toBe(1);
+});
+
+test("collapses and returns focus to the button when Escape is pressed", async () => {
+  const { button, languages, user } = renderLanguageSelector();
+
+  languages[0].focus();
+  await user.keyboard("{Escape}");
+
+  expect(button).toHaveAttribute("aria-expanded", "false");
+  expect(button).toHaveFocus();
+});


### PR DESCRIPTION
Moved `aria-expanded` and the label to the language selector's button instead of the wrapper div. Also fixed the arrow keys, which never moved focus between languages, and Space, which did nothing on a focused language. 

Also added accessibility tests for the language selector for future guarding

### Governance

- [x] Documentation is added or updated where needed
- [x] Test cases are added or updated where needed
- [x] I've read the [contributing document](https://github.com/minvws/.github/blob/main/CONTRIBUTING.md)
- [x] I've read and understand the [Code of Conduct](https://github.com/minvws/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I've signed off all commits in this pull request in accordance with the [Developer Certificate of Origin (DCO)](https://github.com/minvws/.github/blob/main/DCO.txt)

Fixes #436 

